### PR TITLE
fix: prevent premature issue closure (Refs vs Closes check)

### DIFF
--- a/skills/ops/cto-review/SKILL.md
+++ b/skills/ops/cto-review/SKILL.md
@@ -229,6 +229,17 @@ For PRs touching executor, dispatcher, or event routing:
 - Will this break webhook processing? (event router changes)
 - Is there a safe rollback path?
 
+**Premature `Closes` on multi-phase issues?**
+```bash
+# Extract linked issue numbers from PR body (Closes #N or Refs #N)
+gh pr view $PR --repo $REPO --json body --jq '.body' | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+'
+```
+For each issue number found with a `Closes` keyword:
+```bash
+gh issue view ISSUE_N --repo $REPO --json body --jq '.body' | grep -c '- \[ \]' || echo 0
+```
+If the count is > 0 → **MUST FIX**: the PR uses `Closes #N` but the issue has unchecked acceptance criteria. The agent must change `Closes #N` to `Refs #N`. Only the final phase PR that completes all remaining work should use `Closes #N`.
+
 ### Step 3: Post Review Comment
 
 Post the CTO review as a PR comment in the exact format below:

--- a/skills/ops/double-check/SKILL.md
+++ b/skills/ops/double-check/SKILL.md
@@ -209,6 +209,11 @@ REVIEW_EOF
 - If no CI findings exist: write "No CI review comments found — reviewed diff directly"
 - If tests weren't run: explain why (e.g., "deps-only change, no test suite applicable")
 - Verdict must be specific: either "ready for CTO review" or list what still needs work
+- **`Closes` vs `Refs` — MANDATORY check:** Before writing or approving `Closes #N` in any PR description, fetch the linked issue body and scan for unchecked items (`- [ ]`):
+  ```bash
+  gh issue view N --repo REPO --json body --jq '.body' | grep -c '- \[ \]' || echo 0
+  ```
+  If **any** `- [ ]` items remain, use `Refs #N` instead of `Closes #N`. Only use `Closes #N` when ALL acceptance criteria are checked. This prevents GitHub from auto-closing multi-phase issues when only the first PR merges.
 
 ### Step 8: Apply double-checked Label
 


### PR DESCRIPTION
## Summary

- Adds `Refs #NNN` vs `Closes #NNN` guidance to `cto-review` and `double-check` skills
- Prevents premature closure of multi-phase issues when only one phase is merged

Refs fellowship-dev/pylot#202