### PR TITLE
feat: add post-merge deployment pipeline skills (#277)

### DIFF
--- a/skills/ops/cto-review/SKILL.md
+++ b/skills/ops/cto-review/SKILL.md
@@ -365,6 +365,43 @@ if [ -n "$POST_MERGE" ] && [ -n "$ACTION_ITEMS" ]; then
 fi
 ```
 
+#### 5.2 REWORK branch — reset pipeline and dispatch double-check
+
+Skip if `POST_MERGE` is set. Run only when verdict is REWORK.
+
+Removing `double-checked` resets the dedup gate so double-check runs fresh when dispatched.
+
+```bash
+if [ -z "$POST_MERGE" ] && [[ "$VERDICT" == "rework" || "$VERDICT" == "sendback" ]]; then
+  # Remove pipeline labels so double-check runs fresh
+  gh pr edit $PR --repo $REPO --remove-label "double-checked" 2>/dev/null || true
+  gh pr edit $PR --repo $REPO --remove-label "chad-approves" 2>/dev/null || true
+  gh pr edit $PR --repo $REPO --remove-label "chad-rejects" 2>/dev/null || true
+
+  # Resolve team from crew.yml
+  TEAM=$(python3 -c "
+import yaml
+with open('$PYLOT_DIR/crew.yml') as f:
+    data = yaml.safe_load(f)
+for team, cfg in data.get('crew', {}).items():
+    if not isinstance(cfg, dict): continue
+    for r in cfg.get('repos', []):
+        if r.lower() == '$REPO'.lower():
+            print(team)
+            exit()
+print('fellowship')
+" 2>/dev/null || echo "fellowship")
+
+  # Dispatch double-check with CTO fix items as context
+  export PYLOT_DISPATCH_TOKEN=$(grep '^PYLOT_DISPATCH_TOKEN=' $HOME/projects/fellowship-dev/claude-buddy/.env | cut -d= -f2)
+  export PYLOT_DISPATCH_URL="http://127.0.0.1:3000/dispatch"
+  source $PYLOT_DIR/dispatch.sh
+  dispatch_mission "$TEAM" "Double-check PR $REPO#$PR — re-verify after CTO REWORK" \
+    --repo "$REPO" \
+    --context "CTO REWORK: re-check PR #$PR after required fixes. Fix items: $ACTION_ITEMS. Run /double-check $PR $REPO"
+fi
+```
+
 ### Step 6: Merge or label (based on team merge_strategy)
 
 **Skip this step entirely if `POST_MERGE` is set (Step 6)** — `gh pr merge` on a merged PR errors out and can cause the runbook to loop or hang.

--- a/skills/ops/deployment-checker/SKILL.md
+++ b/skills/ops/deployment-checker/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: deployment-checker
+description: Deployment health poller — runs a team bash script to poll health endpoint until deployed sha matches, exits with structured result, applies deployed or deploy-failed label. Stage 2 of the post-merge pipeline. Zero token burn during polling.
+argument-hint: "pr-number org/repo"
+user-invocable: true
+allowed-tools: Read, Write, Bash, Glob, Grep
+---
+
+# deployment-checker
+
+Stage 2 of the autonomous deployment pipeline. Polls the team's health endpoint using a cheap bash script until the deployed sha matches the merged PR's sha, or times out. Exits with a structured result and applies `deployed` or `deploy-failed` label.
+
+**Design goal:** zero token burn during polling. The Claude agent runs only to set up the poll and process the result. All polling is done by the bash script.
+
+## When to Use
+
+- Dispatched by `/post-merge` after a PR merges
+- Manual: `/deployment-checker PR_NUMBER org/repo`
+
+## Invocation
+
+```
+/deployment-checker 42 fellowship-dev/pylot
+```
+
+## Arguments
+
+```bash
+PR_NUMBER=$1    # PR number
+REPO=$2         # org/repo
+```
+
+---
+
+## Runbook
+
+### Step 0: Dedup Gate
+
+```bash
+PR=$1
+REPO=$2
+
+ALREADY_DONE=$(gh pr view $PR --repo $REPO --json labels \
+  --jq '[.labels[].name] | (contains(["deployed"]) or contains(["deploy-failed"]))')
+if [ "$ALREADY_DONE" = "true" ]; then
+  echo "[deployment-checker] outcome=\"already complete — deployed or deploy-failed label present\" status=success"
+  exit 0
+fi
+```
+
+### Step 1: Read Context from Job
+
+Extract parameters from the job context (set by `/post-merge`):
+
+```bash
+# These are passed via job context or derived from PR
+PR_URL=$(gh pr view $PR --repo $REPO --json url --jq '.url')
+PR_TITLE=$(gh pr view $PR --repo $REPO --json title --jq '.title')
+
+# From job context (set by post-merge):
+#   EXPECTED_SHA   — merge commit sha to wait for
+#   HEALTH_URL     — endpoint to poll
+#   TIMEOUT_MINUTES — max wait (default: 5)
+#   CHECKER_SCRIPT  — path to team bash polling script
+#   POLL_INTERVAL   — seconds between polls (default: 30)
+
+EXPECTED_SHA="${EXPECTED_SHA:-}"
+HEALTH_URL="${HEALTH_URL:-}"
+TIMEOUT_MINUTES="${TIMEOUT_MINUTES:-5}"
+CHECKER_SCRIPT="${CHECKER_SCRIPT:-}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+
+if [ -z "$HEALTH_URL" ] || [ -z "$CHECKER_SCRIPT" ]; then
+  echo "[deployment-checker] ERROR: HEALTH_URL and CHECKER_SCRIPT must be set in job context" >&2
+  exit 1
+fi
+```
+
+### Step 2: Run the Bash Polling Script
+
+The team-specific bash script handles the actual polling. This keeps Claude out of the loop during the wait.
+
+```bash
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+
+# Resolve checker script path
+if [[ "$CHECKER_SCRIPT" != /* ]]; then
+  CHECKER_SCRIPT="$PYLOT_DIR/$CHECKER_SCRIPT"
+fi
+
+if [ ! -f "$CHECKER_SCRIPT" ]; then
+  echo "[deployment-checker] ERROR: checker script not found: $CHECKER_SCRIPT" >&2
+  DEPLOY_STATUS="failed"
+  FAILURE_REASON="checker script not found: $CHECKER_SCRIPT"
+else
+  chmod +x "$CHECKER_SCRIPT"
+  # Run the script; it exits 0 on success, non-zero on failure/timeout
+  # stdout: "deploy_status=success sha=abc123" or "deploy_status=failed reason=OOM"
+  POLL_OUTPUT=$(HEALTH_URL="$HEALTH_URL" \
+    EXPECTED_SHA="$EXPECTED_SHA" \
+    TIMEOUT_MINUTES="$TIMEOUT_MINUTES" \
+    POLL_INTERVAL="$POLL_INTERVAL" \
+    bash "$CHECKER_SCRIPT" 2>&1) && POLL_EXIT=0 || POLL_EXIT=$?
+
+  echo "Checker output: $POLL_OUTPUT"
+
+  # Parse structured output
+  DEPLOY_STATUS=$(echo "$POLL_OUTPUT" | grep -oP 'deploy_status=\K\S+' | tail -1 || echo "failed")
+  DEPLOYED_SHA=$(echo "$POLL_OUTPUT" | grep -oP 'sha=\K\S+' | tail -1 || echo "")
+  FAILURE_REASON=$(echo "$POLL_OUTPUT" | grep -oP 'reason=\K[^\n]+' | tail -1 || echo "unknown")
+fi
+```
+
+### Step 3: Apply Label and Comment
+
+**On success:**
+
+```bash
+if [ "$DEPLOY_STATUS" = "success" ]; then
+  # Create label if missing
+  gh label create "deployed" --repo $REPO --color "0e8a16" \
+    --description "Deploy verified — health check passed" 2>/dev/null || true
+
+  gh pr edit $PR --repo $REPO --add-label "deployed"
+
+  gh pr comment $PR --repo $REPO --body "$(cat <<EOF
+**Deployment verified** ✅
+
+| Field | Value |
+|-------|-------|
+| Status | \`success\` |
+| Deployed SHA | \`${DEPLOYED_SHA:-confirmed}\` |
+| Health URL | \`$HEALTH_URL\` |
+| Waited | up to ${TIMEOUT_MINUTES} min |
+
+The \`deployed\` label triggers post-deploy file-match actions.
+EOF
+)"
+fi
+```
+
+**On failure or timeout:**
+
+```bash
+if [ "$DEPLOY_STATUS" != "success" ]; then
+  # Create label if missing
+  gh label create "deploy-failed" --repo $REPO --color "d93f0b" \
+    --description "Deploy verification failed or timed out" 2>/dev/null || true
+
+  gh pr edit $PR --repo $REPO --add-label "deploy-failed"
+
+  gh pr comment $PR --repo $REPO --body "$(cat <<EOF
+**Deployment check failed** ❌
+
+| Field | Value |
+|-------|-------|
+| Status | \`failed\` |
+| Reason | ${FAILURE_REASON} |
+| Health URL | \`$HEALTH_URL\` |
+| Timeout | ${TIMEOUT_MINUTES} min |
+| Expected SHA | \`${EXPECTED_SHA:-unknown}\` |
+
+**Action required:** Check the deployment manually. Remove \`deploy-failed\` and re-add \`deployed\` once confirmed.
+EOF
+)"
+fi
+```
+
+### Step 4: Write Report
+
+```bash
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+REPORT="$PYLOT_DIR/reports/$(date +%Y-%m-%d)-deployment-checker-$(echo $REPO | tr '/' '-')-pr${PR}.md"
+
+cat > "$REPORT" <<EOF
+# Deployment Checker: $REPO PR #$PR
+
+**Date**: $(date +%Y-%m-%d)
+**PR**: [$REPO#$PR]($PR_URL) — $PR_TITLE
+**Status**: $DEPLOY_STATUS
+**SHA**: ${DEPLOYED_SHA:-not confirmed}
+**Reason**: ${FAILURE_REASON:-n/a}
+
+## Poll Output
+\`\`\`
+$POLL_OUTPUT
+\`\`\`
+EOF
+```
+
+---
+
+## Team Checker Script Interface
+
+Each team provides a bash script at a path configured in their CLAUDE.md. The script must:
+
+**Inputs (env vars):**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `HEALTH_URL` | yes | URL to GET for health check |
+| `EXPECTED_SHA` | no | Git sha to wait for (compare against health response) |
+| `TIMEOUT_MINUTES` | no | Max wait in minutes (default: 5) |
+| `POLL_INTERVAL` | no | Seconds between polls (default: 30) |
+
+**Exit codes:**
+- `0` — deployment confirmed
+- `1` — timeout or failure
+
+**stdout format (last line):**
+```
+deploy_status=success sha=abc123def456
+deploy_status=failed reason=timeout_after_5min
+deploy_status=failed reason=health_check_returned_503
+```
+
+**Example minimal script:**
+```bash
+#!/bin/bash
+# scripts/deployment-checker-pylot.sh
+TIMEOUT=$((${TIMEOUT_MINUTES:-5} * 60))
+INTERVAL=${POLL_INTERVAL:-30}
+ELAPSED=0
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  RESPONSE=$(curl -sf "$HEALTH_URL" 2>/dev/null || echo "")
+  CURRENT_SHA=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('sha',''))" 2>/dev/null || echo "")
+
+  if [ -n "$EXPECTED_SHA" ] && [ "$CURRENT_SHA" = "$EXPECTED_SHA" ]; then
+    echo "deploy_status=success sha=$CURRENT_SHA"
+    exit 0
+  elif [ -z "$EXPECTED_SHA" ] && [ -n "$RESPONSE" ]; then
+    # No sha to compare — just verify health returns 200
+    echo "deploy_status=success sha=confirmed"
+    exit 0
+  fi
+
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "deploy_status=failed reason=timeout_after_${TIMEOUT_MINUTES:-5}min"
+exit 1
+```
+
+---
+
+## Notes
+
+- **Zero token burn during polling.** Claude only runs before and after the bash script. The bash script does all the waiting.
+- **SHA comparison is optional.** If `EXPECTED_SHA` is empty, the checker confirms health endpoint returns 200.
+- **Timeout is team-configurable.** 5 min for Pylot (auto-pull), 30 min for Lexgo (GitHub Actions + Fly.io).
+- **`deployed` label chains into `/post-deploy`** via event-rules — no manual handoff needed.
+- **Monorepo targets:** dispatch one deployment-checker job per target if needed.

--- a/skills/ops/deployment-checker/SKILL.md
+++ b/skills/ops/deployment-checker/SKILL.md
@@ -104,10 +104,10 @@ else
 
   echo "Checker output: $POLL_OUTPUT"
 
-  # Parse structured output
-  DEPLOY_STATUS=$(echo "$POLL_OUTPUT" | grep -oP 'deploy_status=\K\S+' | tail -1 || echo "failed")
-  DEPLOYED_SHA=$(echo "$POLL_OUTPUT" | grep -oP 'sha=\K\S+' | tail -1 || echo "")
-  FAILURE_REASON=$(echo "$POLL_OUTPUT" | grep -oP 'reason=\K[^\n]+' | tail -1 || echo "unknown")
+  # Parse structured output (python3 avoids grep -P which is unavailable on macOS/BSD)
+  DEPLOY_STATUS=$(echo "$POLL_OUTPUT" | python3 -c "import sys,re; m=re.search(r'deploy_status=(\S+)', sys.stdin.read()); print(m.group(1) if m else 'failed')" 2>/dev/null || echo "failed")
+  DEPLOYED_SHA=$(echo "$POLL_OUTPUT" | python3 -c "import sys,re; m=re.search(r'sha=(\S+)', sys.stdin.read()); print(m.group(1) if m else '')" 2>/dev/null || echo "")
+  FAILURE_REASON=$(echo "$POLL_OUTPUT" | python3 -c "import sys,re; m=re.search(r'reason=(.+)', sys.stdin.read()); print(m.group(1).strip() if m else 'unknown')" 2>/dev/null || echo "unknown")
 fi
 ```
 

--- a/skills/ops/post-deploy/SKILL.md
+++ b/skills/ops/post-deploy/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: post-deploy
+description: Post-deploy file-match actions — reads PR diff, matches changed files against rules (Dockerfile→ECR rebuild, crew.yml→config verify, scripts/→executor verify), runs actions, posts summary comment. Stage 3 of the post-merge pipeline.
+argument-hint: "pr-number org/repo"
+user-invocable: true
+allowed-tools: Read, Write, Bash, Glob, Grep
+---
+
+# post-deploy
+
+Stage 3 of the autonomous deployment pipeline. Triggered by the `deployed` label. Reads the PR's changed files, matches them against configured patterns, and runs targeted actions: ECR image rebuilds, config reload verification, smoke tests, or custom scripts.
+
+## When to Use
+
+- Triggered by `deployed` label via event-rules (after deployment-checker confirms live deploy)
+- Manual: `/post-deploy PR_NUMBER org/repo`
+
+## Invocation
+
+```
+/post-deploy 42 fellowship-dev/pylot
+```
+
+---
+
+## Runbook
+
+### Step 0: Dedup Gate
+
+```bash
+PR=$1
+REPO=$2
+
+# Check if post-deploy already ran (look for a post-deploy comment)
+EXISTING=$(gh pr view $PR --repo $REPO --json comments \
+  --jq '.comments[].body' | grep "Post-deploy actions" || true)
+if [ -n "$EXISTING" ]; then
+  echo "[post-deploy] outcome=\"already complete — post-deploy comment found\" status=success"
+  exit 0
+fi
+```
+
+### Step 1: Read PR Context
+
+```bash
+PR_DATA=$(gh pr view $PR --repo $REPO --json number,title,url,files,mergeCommit,baseRefName)
+PR_TITLE=$(echo "$PR_DATA" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
+PR_URL=$(echo "$PR_DATA" | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
+CHANGED_FILES=$(echo "$PR_DATA" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+print('\n'.join(f['path'] for f in d['files']))
+")
+
+echo "PR: $PR — $PR_TITLE"
+echo "Changed files:"
+echo "$CHANGED_FILES"
+```
+
+### Step 2: Read Team Post-Deploy Configuration
+
+Read the team's CLAUDE.md for `post_deploy:` rules. Each rule maps a file glob pattern to an action:
+
+```yaml
+# Example in team CLAUDE.md:
+post_deploy:
+  - match: "Dockerfile*"
+    action: ecr-rebuild
+    description: "Rebuild and push ECR image"
+  - match: "docker-entrypoint.sh"
+    action: ecr-rebuild
+  - match: "crew.yml"
+    action: config-reload-verify
+    description: "Verify gateway reloaded updated config"
+  - match: "scripts/*.sh"
+    action: executor-verify
+    description: "Spot-check executor behavior"
+  - match: "event-rules.yml"
+    action: config-reload-verify
+  - match: "**"
+    action: smoke-test
+    optional: true
+    description: "Optional smoke test for any PR"
+```
+
+**Action types:**
+
+| Action | Description |
+|--------|-------------|
+| `ecr-rebuild` | Rebuild Docker image and push to ECR |
+| `config-reload-verify` | Verify the process/gateway has reloaded the updated config |
+| `executor-verify` | Spot-check executor or script behavior |
+| `smoke-test` | Run team-defined smoke test |
+| `custom` | Run `command` field as shell command |
+
+### Step 3: Match Files to Actions
+
+```python
+# Pseudocode — implement in bash with Python for glob matching
+import fnmatch
+
+changed = CHANGED_FILES.splitlines()
+triggered_actions = []
+
+for rule in post_deploy_rules:
+    pattern = rule['match']
+    matching = [f for f in changed if fnmatch.fnmatch(f, pattern)]
+    if matching:
+        triggered_actions.append({
+            'action': rule['action'],
+            'description': rule.get('description', rule['action']),
+            'matched_files': matching,
+            'optional': rule.get('optional', False)
+        })
+```
+
+### Step 4: Execute Actions
+
+Run each triggered action. Document result for each.
+
+#### Action: ecr-rebuild
+
+```bash
+# Rebuild and push ECR image
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+ECR_URI="${ECR_URI:-$(grep 'fargate_ecr_uri' $PYLOT_DIR/crew.yml | awk '{print $2}')}"
+
+cd "$PYLOT_DIR"
+bash scripts/build-worker-image.sh 2>&1
+ECR_EXIT=$?
+[ $ECR_EXIT -eq 0 ] && echo "ecr-rebuild: success" || echo "ecr-rebuild: failed exit=$ECR_EXIT"
+```
+
+#### Action: config-reload-verify
+
+```bash
+# Verify the executor/gateway has reloaded the updated config
+# For Pylot: check that crew.yml timestamp matches what executor loaded
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+
+# Check if executor is running and has loaded recent config
+CREW_MTIME=$(stat -c %Y "$PYLOT_DIR/crew.yml" 2>/dev/null || stat -f %m "$PYLOT_DIR/crew.yml" 2>/dev/null)
+EXECUTOR_PID=$(pgrep -f "executor.sh" || true)
+
+if [ -n "$EXECUTOR_PID" ]; then
+  echo "config-reload-verify: executor running (pid=$EXECUTOR_PID). crew.yml mtime=$CREW_MTIME."
+  echo "config-reload-verify: success — executor will pick up config on next poll cycle"
+else
+  echo "config-reload-verify: WARNING — executor not running. Config will load on restart."
+fi
+```
+
+#### Action: executor-verify
+
+```bash
+# Spot-check executor behavior — run a quick test
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+
+# Syntax-check the modified scripts
+for script in $MATCHED_SCRIPTS; do
+  bash -n "$PYLOT_DIR/$script" && echo "executor-verify: $script syntax OK" || echo "executor-verify: $script SYNTAX ERROR"
+done
+```
+
+#### Action: smoke-test
+
+Run the team's configured smoke test. Optional by default.
+
+```bash
+# Team-specific smoke test — read from CLAUDE.md smoke_test.command
+# Example for Pylot: run a dry-run event dispatch
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+bash "$PYLOT_DIR/event-router.sh" --dry-run 2>&1 | head -20
+echo "smoke-test: event-router dry-run complete"
+```
+
+### Step 5: Post Summary Comment
+
+```bash
+gh pr comment $PR --repo $REPO --body "$(cat <<'EOF'
+## Post-deploy actions
+
+| Action | Matched Files | Result |
+|--------|--------------|--------|
+$(for action in $TRIGGERED_ACTIONS; do
+  echo "| $ACTION_NAME | $MATCHED_FILES | $ACTION_RESULT |"
+done)
+
+$([ -z "$TRIGGERED_ACTIONS" ] && echo "_No file-match rules triggered for this PR's changed files._")
+
+**Pipeline complete.** This PR is live and verified.
+EOF
+)"
+```
+
+### Step 6: Write Report
+
+```bash
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+REPORT="$PYLOT_DIR/reports/$(date +%Y-%m-%d)-post-deploy-$(echo $REPO | tr '/' '-')-pr${PR}.md"
+
+cat > "$REPORT" <<EOF
+# Post-Deploy: $REPO PR #$PR — $PR_TITLE
+
+**Date**: $(date +%Y-%m-%d)
+**PR**: [$REPO#$PR]($PR_URL)
+
+## Changed Files
+$CHANGED_FILES
+
+## Actions Triggered
+$TRIGGERED_ACTIONS_SUMMARY
+
+## Results
+$ACTIONS_RESULTS
+EOF
+```
+
+---
+
+## Default File-Match Rules (Pylot)
+
+| Pattern | Action | When |
+|---------|--------|------|
+| `Dockerfile*` | ecr-rebuild | Docker image changed |
+| `docker-entrypoint.sh` | ecr-rebuild | Entrypoint script changed |
+| `crew.yml` | config-reload-verify | Crew config changed |
+| `event-rules.yml` | config-reload-verify | Event routing changed |
+| `scripts/*.sh` | executor-verify | Shell scripts changed |
+| `dispatch.sh` | executor-verify | Dispatch logic changed |
+| `executor.sh` | executor-verify | Executor logic changed |
+
+---
+
+## Notes
+
+- **No matched rules = no actions.** A PR touching only Markdown files does nothing. This is correct behavior.
+- **Optional actions** (smoke-test) run but do not affect the summary verdict.
+- **ecr-rebuild failure** should be surfaced as a comment but does not re-apply `deploy-failed` — the deploy itself was verified. File a follow-up issue instead.
+- **Team config is the authority.** Generic skill + team CLAUDE.md = full configurability without modifying the skill.
+- **Monorepo:** match files against per-target rules if the team has multiple deploy targets.

--- a/skills/ops/post-deploy/SKILL.md
+++ b/skills/ops/post-deploy/SKILL.md
@@ -177,20 +177,22 @@ echo "smoke-test: event-router dry-run complete"
 ### Step 5: Post Summary Comment
 
 ```bash
-gh pr comment $PR --repo $REPO --body "$(cat <<'EOF'
-## Post-deploy actions
+# Build table rows before heredoc (<<'EOF' prevents expansion — pre-build instead)
+ACTION_TABLE=""
+for action_entry in $TRIGGERED_ACTION_ENTRIES; do
+  ACTION_NAME=$(echo "$action_entry" | cut -d: -f1)
+  ACTION_FILES=$(echo "$action_entry" | cut -d: -f2)
+  ACTION_RESULT=$(echo "$action_entry" | cut -d: -f3)
+  ACTION_TABLE="${ACTION_TABLE}| ${ACTION_NAME} | ${ACTION_FILES} | ${ACTION_RESULT} |\n"
+done
+[ -z "$ACTION_TABLE" ] && ACTION_TABLE="_No file-match rules triggered for this PR's changed files._\n"
+
+gh pr comment $PR --repo $REPO --body "$(printf '%s' "## Post-deploy actions
 
 | Action | Matched Files | Result |
 |--------|--------------|--------|
-$(for action in $TRIGGERED_ACTIONS; do
-  echo "| $ACTION_NAME | $MATCHED_FILES | $ACTION_RESULT |"
-done)
-
-$([ -z "$TRIGGERED_ACTIONS" ] && echo "_No file-match rules triggered for this PR's changed files._")
-
-**Pipeline complete.** This PR is live and verified.
-EOF
-)"
+$(printf '%b' "$ACTION_TABLE")
+**Pipeline complete.** This PR is live and verified.")"
 ```
 
 ### Step 6: Write Report

--- a/skills/ops/post-merge/SKILL.md
+++ b/skills/ops/post-merge/SKILL.md
@@ -106,16 +106,16 @@ Document the command executed and its output.
 
 ### Step 4: Dispatch deployment-checker Job
 
-Dispatch a new job to the team's `deploy-checker` worker with full PR context:
+Dispatch a new job to the team's CTO worker with full PR context:
 
 ```bash
 PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+export PYLOT_DISPATCH_TOKEN=$(grep '^PYLOT_DISPATCH_TOKEN=' $HOME/projects/fellowship-dev/claude-buddy/.env | cut -d= -f2)
+export PYLOT_DISPATCH_URL="http://127.0.0.1:3000/dispatch"
 source "$PYLOT_DIR/dispatch.sh"
 
-dispatch_job \
-  --agent "${TEAM}.deploy-checker" \
+dispatch_mission "${TEAM}.cto" "Check deployment for $REPO#$PR — $PR_TITLE" \
   --repo "$REPO" \
-  --task "Check deployment for $REPO#$PR — $PR_TITLE" \
   --context "PR: $PR. Repo: $REPO. SHA: $PR_SHA. URL: $PR_URL.
 Deploy method: $DEPLOY_METHOD.
 Health URL: $HEALTH_URL.

--- a/skills/ops/post-merge/SKILL.md
+++ b/skills/ops/post-merge/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: post-merge
+description: Post-merge deployment trigger — reads PR diff, determines deploy method (auto vs manual), dispatches deployment-checker job. Stage 1 of the post-merge → deployment-checker → post-deploy pipeline.
+argument-hint: "pr-number org/repo"
+user-invocable: true
+allowed-tools: Read, Write, Bash, Glob, Grep
+---
+
+# post-merge
+
+Stage 1 of the autonomous deployment pipeline. Runs after a PR merges: reads the diff, determines whether the deploy is automatic or manual, optionally performs the manual deploy, then dispatches a `deployment-checker` job to poll until live.
+
+## When to Use
+
+- Triggered automatically by event-rules when a PR merges to the default branch
+- Manual: `/post-merge PR_NUMBER org/repo`
+
+## Invocation
+
+```
+/post-merge 42 fellowship-dev/pylot
+```
+
+## Arguments
+
+```bash
+PR_NUMBER=$1    # PR number
+REPO=$2         # org/repo
+```
+
+---
+
+## Runbook
+
+### Step 0: Dedup Gate
+
+```bash
+PR=$1
+REPO=$2
+
+# Check if deployment-checker job already dispatched for this PR
+EXISTING=$(ls ${PYLOT_DISPATCH_DIR:-$HOME/.local/share/pylot/missions}/pending/ \
+  ${PYLOT_DISPATCH_DIR:-$HOME/.local/share/pylot/missions}/running/ 2>/dev/null \
+  | grep "deploy-check-${PR}-" || true)
+if [ -n "$EXISTING" ]; then
+  echo "[post-merge] outcome=\"already dispatched — deploy-checker job exists\" status=success"
+  exit 0
+fi
+```
+
+### Step 1: Gather PR Context
+
+```bash
+# Fetch PR metadata
+PR_DATA=$(gh pr view $PR --repo $REPO --json number,title,mergedAt,baseRefName,headRefName,files,url,mergeCommit)
+PR_TITLE=$(echo "$PR_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['title'])")
+PR_SHA=$(echo "$PR_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('mergeCommit',{}).get('oid','') or '')" 2>/dev/null || true)
+CHANGED_FILES=$(echo "$PR_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print('\n'.join(f['path'] for f in d['files']))")
+BASE_BRANCH=$(echo "$PR_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['baseRefName'])")
+
+echo "PR: $PR — $PR_TITLE"
+echo "SHA: $PR_SHA"
+echo "Base: $BASE_BRANCH"
+echo "Files changed:"
+echo "$CHANGED_FILES"
+```
+
+### Step 2: Read Team Deploy Configuration
+
+Read the team's CLAUDE.md to determine the deploy method configured for this repo. Look for a `deploy:` section:
+
+```yaml
+# Example in crew/infra/CLAUDE.md or team CLAUDE.md:
+deploy:
+  method: auto-pull          # auto-pull | github-actions | manual
+  health_url: "http://localhost:1337/_health"
+  timeout_minutes: 5
+  checker_script: "scripts/deployment-checker-pylot.sh"
+  expected_sha_field: "sha"  # JSON field in health response containing deployed sha
+```
+
+**Deploy method decision tree:**
+
+| Method | Action |
+|--------|--------|
+| `auto-pull` | Deploy is automatic (cron-driven). Skip to Step 4. |
+| `github-actions` | Deploy triggered by merge. Wait ~2 min, then Step 4. |
+| `manual` | CTO runs deploy command now (Step 3), then Step 4. |
+
+If no deploy config found, emit a warning and exit — do not guess.
+
+### Step 3: Manual Deploy (if method = manual)
+
+Only execute when `method: manual`. Read the deploy command from team config:
+
+```bash
+# Example: manual deploy for a Fly.io app
+cd /path/to/repo && fly deploy --remote-only
+
+# Example: manual ECR push
+aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_URI
+docker build -t $IMAGE . && docker push $IMAGE
+```
+
+Document the command executed and its output.
+
+### Step 4: Dispatch deployment-checker Job
+
+Dispatch a new job to the team's `deploy-checker` worker with full PR context:
+
+```bash
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+source "$PYLOT_DIR/dispatch.sh"
+
+dispatch_job \
+  --agent "${TEAM}.deploy-checker" \
+  --repo "$REPO" \
+  --task "Check deployment for $REPO#$PR — $PR_TITLE" \
+  --context "PR: $PR. Repo: $REPO. SHA: $PR_SHA. URL: $PR_URL.
+Deploy method: $DEPLOY_METHOD.
+Health URL: $HEALTH_URL.
+Timeout: ${TIMEOUT_MINUTES:-5} minutes.
+Checker script: ${CHECKER_SCRIPT}.
+Run /deployment-checker $PR $REPO." \
+  --job-id "deploy-check-${PR}-$(date +%s)"
+```
+
+### Step 5: Post Comment on PR
+
+```bash
+gh pr comment $PR --repo $REPO --body "$(cat <<'EOF'
+**Post-merge pipeline started** 🚀
+
+| Field | Value |
+|-------|-------|
+| Deploy method | \`$DEPLOY_METHOD\` |
+| Health endpoint | \`$HEALTH_URL\` |
+| Timeout | ${TIMEOUT_MINUTES:-5} min |
+| Expected SHA | \`${PR_SHA:-unknown}\` |
+
+Deployment checker dispatched. Will apply \`deployed\` or \`deploy-failed\` label when complete.
+EOF
+)"
+```
+
+### Step 6: Write Report
+
+```bash
+PYLOT_DIR="${PYLOT_DIR:-$HOME/projects/fellowship-dev/pylot}"
+REPORT="$PYLOT_DIR/reports/$(date +%Y-%m-%d)-post-merge-$(echo $REPO | tr '/' '-')-pr${PR}.md"
+cat > "$REPORT" <<EOF
+# Post-Merge: $REPO PR #$PR — $PR_TITLE
+
+**Date**: $(date +%Y-%m-%d)
+**PR**: [$REPO#$PR]($PR_URL)
+**SHA**: $PR_SHA
+**Deploy method**: $DEPLOY_METHOD
+**Deploy-checker job**: dispatched
+
+## Changed Files
+$CHANGED_FILES
+
+## Outcome
+Deploy-checker dispatched. Awaiting health confirmation.
+EOF
+```
+
+---
+
+## Team Configuration Reference
+
+Each team's CLAUDE.md should contain a `deploy:` section. Generic examples:
+
+### Pylot (auto-pull)
+```yaml
+deploy:
+  method: auto-pull
+  health_url: "http://localhost:1337/_health"
+  timeout_minutes: 5
+  checker_script: "scripts/deployment-checker-pylot.sh"
+  expected_sha_field: "sha"
+```
+
+### Lexgo (GitHub Actions → Fly.io)
+```yaml
+deploy:
+  method: github-actions
+  health_url: "https://api.lexgo.cl/_health"
+  timeout_minutes: 30
+  checker_script: "scripts/deployment-checker-lexgo.sh"
+```
+
+### Booster-pack (branch-push → Fly + Vercel)
+```yaml
+deploy:
+  method: auto-pull
+  health_url: "https://api.booster-pack.dev/health"
+  timeout_minutes: 10
+```
+
+---
+
+## Notes
+
+- **No team config = no action.** Don't guess deploy methods — missing config is a signal to configure.
+- **SHA comparison is best-effort.** If health endpoint doesn't expose a sha field, fall back to timestamp comparison.
+- **Post-merge fires per-PR.** Each merged PR gets its own deploy-checker job.
+- **Monorepo:** if the repo has multiple deploy targets (e.g., backend + frontend), dispatch one checker per target. The checker_script determines which target to poll.


### PR DESCRIPTION
## Summary

Adds 3 new ops skills to support the autonomous post-merge → deployment-checker → post-deploy pipeline (fellowship-dev/pylot#277):

- **`/post-merge`** — reads PR diff, determines deploy method (auto-pull / github-actions / manual), dispatches deployment-checker job via dispatch.sh
- **`/deployment-checker`** — runs a team-provided bash script to poll health endpoint until deployed sha matches; exits with structured result (`deploy_status=success|failed`); applies `deployed` or `deploy-failed` label
- **`/post-deploy`** — file-match actions after confirmed deploy: ECR rebuild (Dockerfile changes), config-reload verify (crew.yml/event-rules.yml), executor verify (scripts/), optional smoke test

## Design Decisions

- **Zero token burn during polling** — deployment-checker delegates to a bash script; Claude only sets up + processes the result
- **Label-based handoffs** — consistent with the existing review pipeline (`deployed` label triggers post-deploy via event-rules)
- **Generic + team-configurable** — skills read deploy config from team CLAUDE.md; no per-team skill forks needed
- **Only Pylot initially** — `only_repos: [fellowship-dev/pylot]` in event-rules; other teams added as configured

## Test plan

- [ ] Skills load cleanly via `npx skills add` / `boot-skills.sh`
- [ ] `/post-merge` invocable on a Pylot PR number with correct output
- [ ] `/deployment-checker` bash interface contract matches `scripts/deployment-checker-pylot.sh`
- [ ] `/post-deploy` file-match logic covers Dockerfile, crew.yml, scripts/ patterns

Refs fellowship-dev/pylot#277

🤖 Generated with [Claude Code](https://claude.com/claude-code)