### PR TITLE
feat(popsicle): v2 — agent onboarding with structured docs

### DIFF
--- a/skills/ops/popsicle/SKILL.md
+++ b/skills/ops/popsicle/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: popsicle
-description: Autonomous doc-quality sensor — discovers what matters in a repo, generates docs, validates with fresh agent sessions that can only read the docs. Runs in a loop until docs pass. No rubric needed.
+description: Agent onboarding doc generator — discovers what matters in a repo, writes structured docs an agent can navigate, validates with fresh sessions. Enforces size budgets and doc-type separation.
 user-invocable: true
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 
 # Popsicle
 
-Autonomous doc-quality sensor. Discover. Generate. Validate. Loop.
+Agent onboarding doc generator. Discover. Structure. Validate. Loop.
 
-**No rubric needed.** Popsicle reads the code, figures out what matters, writes/updates docs, then spawns fresh agent sessions that can ONLY see the docs to verify they're actually useful.
+**Purpose:** Make any repo agent-ready. A fresh AI agent with zero context should be able to read the docs and start working — without reading source code first.
 
 **Install via npx:**
 ```bash
@@ -18,8 +18,8 @@ npx skills add fellowship-dev/dogfooded-skills/skills/ops/popsicle
 
 ## When to Use
 
+- **New repo onboarding:** Bootstrap agent-readable docs from scratch.
 - **After major refactors:** Verify docs still match reality.
-- **New repo onboarding:** Bootstrap docs from scratch and validate them.
 - **Periodic health check:** Catch doc rot before it compounds.
 - **Before handing a repo to agents:** Confirm docs give a fresh agent enough to work independently.
 
@@ -28,6 +28,54 @@ npx skills add fellowship-dev/dogfooded-skills/skills/ops/popsicle
 Whatever you discover during research is the **answer key**. The repo docs are the **test**. The fresh validation session is the **student**.
 
 Discovery artifacts (knowledge map) MUST live in `/tmp`, never in the repo. The validation sessions must have zero access to discovery artifacts. If they can see what you found, the test is worthless.
+
+---
+
+## Doc Types — What Goes Where
+
+Agents need three kinds of documentation. Popsicle enforces separation:
+
+### 1. `CLAUDE.md` — Agent Instructions (≤80 lines)
+
+The entry point. An agent reads this first. It answers: "What is this repo, how do I work in it, and what rules must I follow?"
+
+**What belongs here:**
+- Project identity (one sentence: what this is, what stack)
+- How to install, run, test, deploy (commands only, no explanation)
+- Key rules and constraints (things that break if violated)
+- Pointers to `docs/` for deeper reference
+
+**What does NOT belong here:**
+- Architecture explanations (→ `docs/architecture.md`)
+- API reference (→ `docs/api.md`)
+- Config/env var tables longer than 5 rows (→ `docs/configuration.md`)
+- Runbooks or troubleshooting (→ `docs/runbook.md`)
+- History, context, or "why we built this" (→ README.md or nowhere)
+
+**Budget: ≤80 lines.** If CLAUDE.md exceeds 80 lines after your changes, refactor: move detail into `docs/` and replace with a one-line pointer. Count lines with `wc -l CLAUDE.md`.
+
+### 2. `docs/*.md` — Reference Documentation
+
+Deep knowledge an agent navigates to when working on specific areas. Each file covers one topic. An agent should be able to find the right file by name alone.
+
+**Standard files** (create only the ones the repo needs):
+- `docs/architecture.md` — system boundaries, data flow, key abstractions, service map
+- `docs/api.md` — routes, endpoints, request/response shapes
+- `docs/configuration.md` — env vars, feature flags, config files with all options documented
+- `docs/workflows.md` — dev workflow, CI/CD, deploy process, release steps
+- `docs/data-model.md` — database schema, key tables, relationships
+- `docs/glossary.md` — domain terms that aren't obvious from code (only if needed)
+- `docs/runbook.md` — how to debug common issues, operational procedures
+
+**Rules:**
+- One topic per file. If a file exceeds 200 lines, split it.
+- File names must be self-descriptive — an agent picks which file to read based on the name.
+- No `docs/misc.md` or `docs/notes.md` — if it doesn't have a clear topic, it doesn't belong.
+- Link between doc files when concepts cross boundaries.
+
+### 3. `README.md` — Human Documentation (don't touch)
+
+README.md is for humans: badges, screenshots, marketing copy, contribution guides. **Popsicle does not modify README.md.** If critical info exists only in README.md and belongs in agent docs, copy the relevant facts into the appropriate `docs/` file or CLAUDE.md — don't restructure the README.
 
 ---
 
@@ -52,16 +100,29 @@ Check for `--loop` flag: if present (or if dispatched as a crew mission), run th
 
 ### Phase 1: Discover (Build the Answer Key)
 
-Scan the repo systematically. Build a knowledge map of what someone SHOULD be able to learn from good docs.
+Scan the repo systematically. Build a knowledge map of what an agent SHOULD be able to learn from good docs.
 
 **What to scan:**
 - Entry points (`main`, `index`, `app`, CLI entrypoints)
-- Public functions and their signatures
+- How to install, run, test (the commands, not just that they exist)
 - API routes and endpoints
 - Config files (env vars, feature flags, deploy config)
 - Important abstractions (key classes, modules, patterns)
 - Architecture (service boundaries, data flow, external deps)
-- Dev workflow (how to run, test, deploy)
+- Dev workflow (CI, deploy, release process)
+- Domain-specific terms that aren't obvious from code
+
+**Classify each concept by doc type** — where should an agent find this?
+
+| Category | Target file |
+|----------|-------------|
+| identity, stack, run/test commands, key rules | `CLAUDE.md` |
+| system design, data flow, service boundaries | `docs/architecture.md` |
+| routes, endpoints, request/response | `docs/api.md` |
+| env vars, config files, feature flags | `docs/configuration.md` |
+| dev workflow, CI/CD, deploy, release | `docs/workflows.md` |
+| database schema, key tables | `docs/data-model.md` |
+| domain terms | `docs/glossary.md` |
 
 **Pick 5-10 concepts per iteration.** Rotate across iterations so you eventually cover the whole repo. Don't repeat concepts that already PASSed.
 
@@ -71,8 +132,6 @@ Write the knowledge map to a temp file:
 KNOWLEDGE_MAP="/tmp/popsicle-knowledge-$(date +%s).json"
 ```
 
-Use `python3` to write structured JSON:
-
 ```bash
 python3 -c "
 import json, sys
@@ -80,10 +139,12 @@ concepts = [
     {
         'id': 'concept-1',
         'category': 'architecture',
+        'target_file': 'docs/architecture.md',
         'name': 'Short name',
-        'description': 'What a dev should know about this',
+        'description': 'What an agent should know about this',
         'evidence': 'Where you found it in the code (file:line)',
-        'question': 'Question to ask the validation session'
+        'question': 'Question to ask the validation session',
+        'nav_question': 'Which doc file would you read to learn about this?'
     },
     # ... 5-10 concepts
 ]
@@ -96,31 +157,62 @@ with open('$KNOWLEDGE_MAP', 'w') as f:
 
 ---
 
-### Phase 2: Generate (Improve the Docs)
+### Phase 2: Generate (Write Structured Docs)
 
-Read existing docs:
-- `CLAUDE.md`
-- `README.md`
-- `docs/` directory
-- `ARCHITECTURE.md`
-- Any other markdown in the repo root
+Read existing docs: `CLAUDE.md`, `docs/` directory, `README.md` (read-only reference).
 
-Compare against the knowledge map. For each concept:
-1. Is it documented anywhere? Search the docs.
-2. If missing or vague, update the most appropriate doc file.
-3. If no appropriate file exists, add to `CLAUDE.md` (preferred) or create a focused doc in `docs/`.
+For each concept in the knowledge map:
+1. Does the target file exist? If not, create it with a `# Title` header.
+2. Is the concept already documented in the right place? If yes, skip.
+3. If documented in the wrong place (e.g., architecture details in CLAUDE.md), move it.
+4. If missing, write it in the target file.
 
-**Rules for doc changes:**
-- Be concise. One paragraph per concept is usually enough.
-- Don't restructure existing docs — add to them.
-- Don't duplicate info that's already clear.
-- Focus on the gaps: undocumented entry points, missing env vars, unexplained architecture decisions.
+**After all concepts are placed, enforce budgets:**
+
+```bash
+CLAUDE_LINES=$(wc -l < CLAUDE.md 2>/dev/null || echo 0)
+if [ "$CLAUDE_LINES" -gt 80 ]; then
+  echo "CLAUDE.md is $CLAUDE_LINES lines — over 80-line budget. Refactor."
+fi
+```
+
+If CLAUDE.md exceeds 80 lines:
+1. Identify sections that are reference material (tables >5 rows, detailed explanations, examples).
+2. Move them to the appropriate `docs/` file.
+3. Replace with a one-line pointer: `See [docs/configuration.md](docs/configuration.md) for full env var reference.`
+4. Re-check the line count.
+
+**CLAUDE.md structure template** (adapt to repo, don't force sections that don't apply):
+
+```markdown
+# {Repo Name}
+
+{One sentence: what this is and what stack.}
+
+## Quick Start
+
+{install, run, test commands — no prose, just the commands}
+
+## Key Rules
+
+{Things that break if violated — max 5 bullets}
+
+## Project Structure
+
+{Only if non-obvious — 5-10 lines max showing key directories}
+
+## Reference
+
+- [Architecture](docs/architecture.md) — {one-line summary}
+- [Configuration](docs/configuration.md) — {one-line summary}
+- [API](docs/api.md) — {one-line summary}
+```
 
 Commit the doc changes:
 
 ```bash
-git add -A
-git commit -m "docs: popsicle iteration $ITERATION — fill doc gaps
+git add CLAUDE.md docs/
+git commit -m "docs: popsicle iteration $ITERATION — structured agent docs
 
 Concepts targeted: [list the concept names]"
 ```
@@ -131,58 +223,79 @@ Concepts targeted: [list the concept names]"
 
 **Critical: the knowledge map must be invisible to validation sessions.** It's already in `/tmp` (not in the repo), so fresh sessions can't see it.
 
-For each concept in the knowledge map, spawn 2 fresh `claude -p` sessions. Each session gets ONLY the repo context — no discovery artifacts, no hints. Use `--model sonnet` for validators — they only need to read docs and answer questions. Two independent sessions per concept ensures signal quality — if both pass with clean context, the docs genuinely work.
+Two types of validation per concept:
 
 ```bash
 RESULTS_DIR="/tmp/popsicle-results-$(date +%s)"
 mkdir -p "$RESULTS_DIR"
 ```
 
-For each concept, run 2 independent sessions:
+**Test A — Content validation** (can the agent answer from docs?):
 
 ```bash
-# For concept N, session S:
 claude -p "You are examining the repository at $REPO_ROOT. \
-Using ONLY the documentation and docs in this repo (CLAUDE.md, README, docs/, etc.), \
+Using ONLY the documentation in this repo (CLAUDE.md, docs/*.md), \
 answer this question. Do not read source code — only docs. \
 If the docs don't cover this, say 'NOT DOCUMENTED'. \
 \
-Question: [concept.question from knowledge map]" \
+Question: [concept.question]" \
   --model sonnet --output-format text \
-  2>/dev/null > "$RESULTS_DIR/concept-N-session-S.txt"
+  2>/dev/null > "$RESULTS_DIR/concept-N-content-1.txt"
 ```
 
-**Each invocation must be truly fresh — no `--continue`, no shared context.** Run up to 3 sessions in parallel to save time (background the `claude -p` calls and `wait`). Do not exceed 3 concurrent sessions — small machines will OOM.
+Run 2 independent content sessions per concept.
+
+**Test B — Navigation validation** (can the agent find WHERE to look?):
+
+```bash
+claude -p "You are examining the repository at $REPO_ROOT. \
+Look at the documentation files available (CLAUDE.md, docs/*.md). \
+Do NOT read the full contents — only look at file names and headers. \
+\
+Question: Which specific doc file would you open to learn about: [concept.nav_question]? \
+Answer with just the file path." \
+  --model sonnet --output-format text \
+  2>/dev/null > "$RESULTS_DIR/concept-N-nav.txt"
+```
+
+Run 1 navigation session per concept.
+
+**Run up to 3 sessions in parallel** (background and `wait`). Do not exceed 3 concurrent — small machines will OOM.
 
 ---
 
 ### Phase 4: Grade
 
-Read each validation response. For each concept, score it:
+For each concept, score on two axes:
 
-- **PASS** (2/2): Both sessions found and explained the concept correctly from docs alone.
-- **WEAK** (1/2): One session got it, one didn't. Docs exist but aren't clear enough.
-- **FAIL** (0/2): Neither session could answer from docs. Gap confirmed.
+**Content score** (from Test A):
+- **PASS** (2/2): Both sessions answered correctly from docs.
+- **WEAK** (1/2): One got it, one didn't.
+- **FAIL** (0/2): Neither could answer.
 
-Use your own judgment — semantic understanding matters more than keyword matching. A response that explains the concept in different words is still a PASS.
+**Navigation score** (from Test B):
+- **HIT**: Agent pointed to the correct file (matches `target_file` from knowledge map).
+- **MISS**: Agent pointed to wrong file or couldn't find it.
 
-Compute the pass rate:
+**Combined verdict:**
+- **PASS**: Content PASS + Nav HIT
+- **PARTIAL**: Content PASS + Nav MISS (info exists but hard to find), or Content WEAK + Nav HIT
+- **FAIL**: Content FAIL (regardless of nav), or Content WEAK + Nav MISS
+
+Compute the pass rate (PASS only, PARTIAL counts as half):
 
 ```bash
-PASS_RATE=$((PASS_COUNT * 100 / TOTAL_CONCEPTS))
+SCORE=$((PASS_COUNT * 100 + PARTIAL_COUNT * 50))
+PASS_RATE=$((SCORE / TOTAL_CONCEPTS))
 ```
 
 ---
 
 ### Phase 5: Report
 
-Write the report:
-
 ```bash
 REPORT="$REPO_ROOT/docs/popsicle-report-${TODAY}.md"
 ```
-
-Report format:
 
 ```markdown
 # Popsicle Report — {REPO_NAME}
@@ -190,25 +303,34 @@ Report format:
 **Date**: {TODAY}
 **Iteration**: {N}
 **Concepts tested**: {count}
-**Pass rate**: {PASS_COUNT}/{TOTAL} ({PCT}%)
+**Pass rate**: {PCT}%
+
+## Doc Structure
+
+| File | Lines | Status |
+|------|-------|--------|
+| CLAUDE.md | {n} | {ok / over budget} |
+| docs/architecture.md | {n} | {exists / created / n/a} |
+| docs/configuration.md | {n} | {exists / created / n/a} |
+| ... | | |
 
 ## Results
 
-| # | Concept | Category | S1 | S2 | Verdict |
-|---|---------|----------|----|----|---------|
-| 1 | {name}  | arch     | PASS | PASS | PASS |
-| 2 | {name}  | config   | PASS | FAIL | WEAK |
-| 3 | {name}  | api      | FAIL | FAIL | FAIL |
+| # | Concept | Target File | Content | Nav | Verdict |
+|---|---------|-------------|---------|-----|---------|
+| 1 | {name}  | docs/arch.. | PASS    | HIT | PASS    |
+| 2 | {name}  | CLAUDE.md   | WEAK    | HIT | PARTIAL |
+| 3 | {name}  | docs/api..  | FAIL    | MISS| FAIL    |
 
 ## Gaps Remaining
 
-- **{concept}**: {why it failed — what's missing from docs}
+- **{concept}**: {why it failed — what's missing or misplaced}
 - ...
 
 ## Doc Changes This Iteration
 
-- Updated `CLAUDE.md`: added {what}
-- Updated `docs/architecture.md`: added {what}
+- Created `docs/architecture.md`: {what}
+- Refactored `CLAUDE.md`: moved {what} to `docs/configuration.md`
 - ...
 ```
 
@@ -225,7 +347,7 @@ git commit -m "docs: popsicle report — iteration $ITERATION, ${PASS_RATE}% pas
 
 ```bash
 if [ "$PASS_RATE" -ge "$PASS_THRESHOLD" ]; then
-  echo "Pass rate ${PASS_RATE}% >= ${PASS_THRESHOLD}%. Docs are good enough. Stopping."
+  echo "Pass rate ${PASS_RATE}% >= ${PASS_THRESHOLD}%. Docs are agent-ready. Stopping."
   exit 0
 fi
 
@@ -238,9 +360,10 @@ ITERATION=$((ITERATION + 1))
 ```
 
 If pass rate is below threshold and iterations remain:
-1. Read the FAILed concepts from the report.
-2. Go back to **Phase 2** — target the FAILed concepts as priority.
-3. Re-discover only if you need fresh concepts to rotate in.
+1. Read the FAILed and PARTIAL concepts from the report.
+2. For nav MISSes: restructure — move content to a more discoverable location or rename the file.
+3. For content FAILs: improve the docs in the target file.
+4. Go back to **Phase 2**.
 
 ---
 
@@ -261,20 +384,12 @@ Discovery artifacts are ephemeral. Reports and doc changes are committed.
 
 **One-shot** (single iteration, report only):
 ```bash
-# As a slash command
 /popsicle
-
-# Via claude -p
-claude -p "Run the popsicle skill on this repo. One iteration only."
 ```
 
 **Loop** (iterate until pass rate >= 80% or max 5 iterations):
 ```bash
-# As a slash command
 /popsicle --loop
-
-# Via claude -p
-claude -p "Run the popsicle skill on this repo. Loop until pass rate >= 80%."
 ```
 
 **Crew mission** (dispatched via Pylot):
@@ -289,8 +404,9 @@ curl -X POST "$PYLOT_DISPATCH_URL" \
 
 ## Design Principles
 
-1. **No rubric.** The skill discovers what matters by reading the code. No upfront configuration needed.
-2. **Anti-cheat by architecture.** Discovery artifacts live in `/tmp`. Validation sessions are fresh. The test is honest.
-3. **Docs get better every iteration.** This isn't just measurement — it actively fills gaps.
-4. **Fresh sessions are the oracle.** If a fresh agent can't learn it from docs, the docs are broken.
-5. **Loop-first.** One iteration is useful. Five iterations with targeted fixes is transformative.
+1. **Agent-first.** Docs are for AI agents, not humans. README.md is for humans — popsicle doesn't touch it.
+2. **Structure over volume.** 80 lines of well-placed docs beats 300 lines in one file. If an agent can't find it by filename, the docs are broken.
+3. **Anti-cheat by architecture.** Discovery artifacts live in `/tmp`. Validation sessions are fresh. The test is honest.
+4. **Navigate then read.** Validation tests both: can the agent find the right file (nav), AND can it answer from that file (content).
+5. **Budget-enforced.** CLAUDE.md ≤80 lines. Individual doc files ≤200 lines. Overflow triggers refactoring, not bloat.
+6. **Loop-first.** One iteration is useful. Five iterations with structural fixes is transformative.


### PR DESCRIPTION
## Summary
- **Doc-type separation**: CLAUDE.md (≤80 lines, agent entry point) vs `docs/*.md` (deep reference) vs README.md (humans, untouched)
- **Size budgets**: CLAUDE.md ≤80 lines, doc files ≤200 lines. Overflow triggers refactoring, not bloat.
- **Navigation validation**: New Test B checks if agent can find the right file by name alone — not just answer from docs.
- **Combined scoring**: Content (PASS/WEAK/FAIL) × Navigation (HIT/MISS) → combined verdict. PARTIAL counts as half.
- **Concept classification**: Each concept maps to a target file at discovery time (`docs/architecture.md`, `docs/api.md`, etc.)
- **CLAUDE.md template**: identity → quick start → key rules → structure → reference links

v1 produced good content but dumped everything into CLAUDE.md. v2 produces structured, navigable docs an agent can actually use at scale.

## Test plan
- [ ] Dispatch on flowchad (has v1 docs — compare before/after)
- [ ] Verify CLAUDE.md stays under 80 lines
- [ ] Verify `docs/` files are created with self-descriptive names
- [ ] Verify navigation validation catches misplaced content

🤖 Generated with [Claude Code](https://claude.com/claude-code)