### PR TITLE
procedure-builder: vendor _core/ + add Stage 00 bootstrap

### DIFF
--- a/skills/meta/procedure-builder/SKILL.md
+++ b/skills/meta/procedure-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: procedure-builder
-description: Scaffold a multi-stage ICM procedure from a structured spec -- five-stage pipeline producing workflow map, stage contracts, folder scaffold, onboarding questionnaire, and validation report.
+description: Scaffold a multi-stage ICM procedure from a structured spec -- six-stage pipeline that bootstraps `_core/` if needed, then produces the workflow map, stage contracts, folder scaffold, onboarding questionnaire, and validation report.
 argument-hint: "[spec-file-path]"
 user-invocable: true
 allowed-tools: Read, Write, Bash, Glob, Grep
@@ -8,7 +8,7 @@ allowed-tools: Read, Write, Bash, Glob, Grep
 
 # procedure-builder
 
-Build a complete ICM (Interpreted Context Methodology) procedure from a structured spec file. Follows the same five-stage pipeline as the ICM workspace-builder, producing the same intermediate artifacts at each stage.
+Build a complete ICM (Interpreted Context Methodology) procedure from a structured spec file. Bootstraps `_core/` on first run, then follows the five-stage pipeline of the ICM workspace-builder.
 
 ## When to Use
 
@@ -32,9 +32,55 @@ The spec file must follow the format in `references/spec-format.md`.
 
 ## Procedure
 
-This skill runs five stages sequentially, each producing an artifact that feeds the next. The stages mirror the ICM workspace-builder exactly.
+This skill runs six stages sequentially. The first is a one-time bootstrap; the remaining five mirror the ICM workspace-builder exactly. Each stage produces an artifact that feeds the next.
 
 Read `references/icm-conventions.md` before starting -- every convention applies.
+
+### Stage 00: Bootstrap `_core/`
+
+**Ensure the workspace has the canonical ICM `_core/` directory at the repo root before any scaffolding runs.** This makes a fresh repo ICM-compliant with one command and keeps later stages offline-deterministic. Run on every invocation; no-op if already bootstrapped.
+
+**Input:** The current working directory (must be a repo root).
+
+**Process:**
+
+1. Check whether `_core/` exists at the repo root:
+   ```bash
+   test -d "_core" && echo "present" || echo "missing"
+   ```
+2. If present, skip to Stage 01. Print `[bootstrap] _core/ already present, skipping`.
+3. If missing, copy the vendored template from this skill into the repo root. Resolve the skill's installed location (one of: `.claude/skills/procedure-builder/`, `.agents/skills/procedure-builder/`, `~/.claude/skills/procedure-builder/`):
+   ```bash
+   for SKILL_DIR in \
+       ".claude/skills/procedure-builder" \
+       ".agents/skills/procedure-builder" \
+       "$HOME/.claude/skills/procedure-builder"; do
+     if [ -d "$SKILL_DIR/templates/_core" ]; then
+       cp -R "$SKILL_DIR/templates/_core" "./_core"
+       break
+     fi
+   done
+   ```
+4. Verify the copy succeeded:
+   - `_core/CONVENTIONS.md` exists and is non-empty
+   - `_core/placeholder-syntax.md` exists
+   - `_core/templates/` contains `stage-context-template.md` and `questionnaire-template.md`
+   - `_core/SOURCE.md` exists (documents provenance)
+5. Run the audit checks:
+   - `_core/` is a directory at the repo root, not nested elsewhere
+   - All expected files are present and non-empty
+   - File contents match the bundled templates byte-for-byte (`diff -r ./_core "$SKILL_DIR/templates/_core"` returns no differences)
+
+**Output:** Write `bootstrap-result.md` to the working directory:
+```markdown
+# Bootstrap Result
+- bootstrapped: yes | no
+- core_files: <count>
+- skill_dir: <path>
+- audit: PASS | FAIL
+```
+
+If audit fails, stop the procedure -- do not proceed to Stage 01 with a broken `_core/`.
 
 ### Stage 01: Discovery
 

--- a/skills/meta/procedure-builder/templates/_core/CONVENTIONS.md
+++ b/skills/meta/procedure-builder/templates/_core/CONVENTIONS.md
@@ -1,0 +1,307 @@
+# MWP Conventions
+
+The rules for building and maintaining MWP workspaces. This is the canonical source. Every workspace follows these patterns.
+
+---
+
+## Five-Layer Routing Architecture
+
+Agents read down the layers. They stop as soon as they have what they need.
+
+```
+Layer 0: CLAUDE.md           -> "Where am I?"            (always loaded, ~800 tokens)
+Layer 1: CONTEXT.md          -> "Where do I go?"          (read on entry, ~300 tokens)
+Layer 2: Stage CONTEXT.md    -> "What do I do?"            (read per-task, ~200-500 tokens)
+Layer 3: Reference material  -> "What rules apply?"        (loaded selectively, varies)
+Layer 4: Working artifacts   -> "What am I working with?"  (loaded selectively, varies)
+```
+
+**Layer 0 -- CLAUDE.md** is auto-loaded by Claude Code into every conversation. It contains the folder map, naming conventions, and a routing table that points to workspace-level files. One per workspace.
+
+**Layer 1 -- Top-level CONTEXT.md** is the first thing an agent reads when entering the workspace. It contains a task routing table that maps task types to specific stage folders. One per workspace.
+
+**Layer 2 -- Stage CONTEXT.md files** live inside each stage folder. They contain the scope definition, what-to-load tables, and step-by-step process. One per stage. Layer 2 is the control point of the system -- its Inputs table determines exactly which files from Layers 3 and 4 the agent loads.
+
+**Layer 3 -- Reference material** is the persistent context: design systems, voice rules, build conventions, style guides, domain knowledge bundled as skill files. These files are configured once during workspace setup and remain stable across every run of the pipeline. They live in `references/` folders within stages, in workspace-level configuration folders (like `brand-vault/` or `design-system/`), in `shared/`, and in `skills/`. Larger reference collections can include their own CONTEXT.md routing files to help agents navigate within the collection.
+
+**Layer 4 -- Working artifacts** are the per-run context: previous stage outputs, user-provided source material, anything specific to this particular run. These files are produced and consumed during execution and change every time the pipeline runs. They live in `output/` folders.
+
+The distinction between Layers 3 and 4 matters because they require different things from the model. Layer 3 material needs to be internalized as constraints and patterns -- write like this, use these colors, follow these conventions. Layer 4 material needs to be processed as input -- transform this research into a script, convert this script into a specification. Layer 3 is the factory. Layer 4 is the product.
+
+A rendering agent might only need Layers 0 through 2. A script-writing agent reads down to Layer 4 to access both voice rules (Layer 3) and source material (Layer 4). No agent reads everything.
+
+Every token of irrelevant context is a token of diluted attention. Workspace CLAUDE.md files should explicitly map each task to its minimal required files. Loading more context does not make output better. It makes it worse.
+
+---
+
+## Pattern 1: Stage Contracts
+
+Every stage CONTEXT.md follows the same three-section shape:
+
+```markdown
+## Inputs
+
+| Source | File/Location | Section/Scope | Why |
+|--------|--------------|---------------|-----|
+| ... | ... | ... | ... |
+
+## Process
+
+1. Step one
+2. Step two
+3. Step three
+
+## Outputs
+
+| Artifact | Location | Format |
+|----------|----------|--------|
+| ... | ... | ... |
+```
+
+This is the contract. It is simple enough that a non-technical user can read it and understand what is happening. It is structured enough that an agent can follow it reliably. Every stage follows this exact shape. No exceptions.
+
+---
+
+## Pattern 2: Stage Handoffs via Output Folders
+
+Every stage has an `output/` subfolder. The agent writes its artifact there. The next stage reads from the previous stage's `output/` folder.
+
+The convention:
+- Stage N produces: `stages/0N-name/output/artifact-name.md`
+- Stage N+1's CONTEXT.md says: "Read `../0N-name/output/artifact-name.md` as your input"
+
+This is the handoff. A human can open the output file, edit it, and the next stage picks up the edited version. No state management. No orchestration layer. Just files in predictable places.
+
+File naming in output folders: `[topic-slug]-[stage-artifact].md`
+- Example: `hello-world-script.md`, `hello-world-spec.md`
+
+---
+
+## Pattern 3: One-Way Cross-References
+
+Every folder points outward to what it needs. No folder points back.
+
+If Stage 03 references Stage 02's component registry, Stage 02 does NOT reference anything in Stage 03. If the brand-vault is referenced by multiple stages, the brand-vault does NOT reference any stage.
+
+This prevents reference growth from going N-squared as the system scales. When adding a new reference, check: "Does the target file already reference my folder?" If yes, restructure.
+
+---
+
+## Pattern 4: Selective Section Routing
+
+CONTEXT.md Inputs tables do not just say "read voice-rules.md." They say "read the Voice Rules section of voice-rules.md."
+
+This keeps token cost low. A 150-line file might have only 60 lines of actionable rules for a specific stage. The other 90 lines of strategic rationale stay unloaded.
+
+Format in CONTEXT.md Inputs tables:
+
+```
+| File | Section to Load | Why |
+|------|----------------|-----|
+| voice-rules.md | "Voice Rules" through "What the Voice Is NOT" | Tone guidance |
+| identity.md | "One-Sentence Brand" and "Audience" sections | Audience context |
+```
+
+When a full file is needed, write "Full file" in the Section/Scope column.
+
+---
+
+## Pattern 5: Canonical Sources
+
+Every piece of information has ONE home. Other files point there. They do not duplicate it.
+
+If you need to update a rule, you update it in one place. Every other file has a pointer. If you find the same information in two files, one of them should be replaced with a reference to the other.
+
+Smell test: search the repo for a specific phrase. If it appears in more than one file and both instances are meant to be authoritative, one needs to become a pointer.
+
+---
+
+## Pattern 6: CONTEXT.md = Routing, Not Content
+
+CONTEXT.md files answer three questions:
+1. What is this folder?
+2. What do I load?
+3. What is the process?
+
+They never contain the actual reference material. No definitions. No rules. No extended examples. No voice guidelines. This keeps them small (25-80 lines) and prevents them from going stale when the content they would otherwise duplicate gets updated.
+
+If you find yourself writing more than a one-sentence description in a CONTEXT.md, that content belongs in a separate file that the CONTEXT.md points to.
+
+---
+
+## Pattern 7: Tool Prerequisites
+
+Some stages require external tools (Node.js, LibreOffice, ffmpeg, etc.). Setup guides for these tools live in the `references/` folder of the stage that uses them (e.g., `stages/03-build/references/remotion-setup.md`).
+
+Setup guides are written for someone who has never installed the tool: what it is (one sentence), installation steps, how to verify it works, and how the workspace uses it.
+
+If a tool is needed by multiple stages, it can live in `shared/` instead. The `setup` onboarding process should check which tools are needed based on the user's answers and point them to the right setup guide.
+
+Note: When a workspace bundles skills (Pattern 9), many tools that would have needed separate prerequisites (scripts, libraries, utilities) come bundled inside the skill folder. Only tools that require system-level installation (Node.js, Python, LibreOffice) still need setup guides.
+
+---
+
+## Trigger Keywords
+
+Every workspace recognizes these triggers:
+
+**`setup`** -- Starts the onboarding questionnaire. The agent reads `setup/questionnaire.md`, asks the questions conversationally, collects answers, replaces placeholders across the workspace, and verifies no placeholders remain.
+
+**`status`** -- Shows pipeline completion. The agent scans all `stages/*/output/` folders and renders an ASCII pipeline diagram:
+
+```
+Pipeline Status: [workspace-name]
+
+  [01-stage-name]  ------>  [02-stage-name]  ------>  [03-stage-name]
+     COMPLETE                  PENDING                  PENDING
+  (artifact.md)              (empty)                  (empty)
+```
+
+For each stage: if the output folder contains files (other than .gitkeep), the stage is COMPLETE and the filenames are listed. If the output folder is empty or contains only .gitkeep, the stage is PENDING.
+
+Workspaces can define additional trigger keywords in their own CLAUDE.md.
+
+---
+
+## Naming Conventions
+
+- Folders and files: `lowercase-with-hyphens`
+- Stage folders: zero-padded numbers prefix: `01-`, `02-`, `03-`
+- Placeholders: `{{SCREAMING_SNAKE_CASE}}`
+- Output artifacts: `[topic-slug]-[artifact-type].md`
+- No spaces in file or folder names
+
+---
+
+## Pattern 8: Questionnaire Design
+
+Onboarding questionnaires configure the production system, not a specific run. They follow these rules:
+
+1. **Flat structure.** No category groupings. Just a numbered list of questions.
+2. **All at once.** Every question appears in one pass. The user should be able to answer everything in a single message.
+3. **System-level only.** Questions configure things that stay the same across runs: identity, brand, design, tool preferences, default workflow. Per-run details (project name, topic, audience, scope) are collected conversationally at the start of each pipeline run by the entry stage.
+4. **Derive, do not ask.** If a field can be inferred from another answer, the agent fills it in. List derived fields under the question they depend on. Do not add a separate question.
+5. **Sensible defaults.** Every question should have a default or example so the user can skip what they do not care about.
+6. **Ask once, never again.** After setup, the user should never see these questions again. The answers are baked into the workspace files permanently.
+
+The questionnaire template at `_core/templates/questionnaire-template.md` encodes these rules.
+
+---
+
+## Pattern 9: Bundled Skills
+
+Workspaces can bundle Claude Code skills directly into a `skills/` folder. This gives agents domain-specific knowledge (APIs, best practices, code examples) without requiring the user to have the skills installed globally.
+
+```
+workspace/
+├── skills/
+│   ├── [skill-name]/          (copied from ~/.claude/skills/ or cloned from GitHub)
+│   │   ├── SKILL.md           (skill entry point)
+│   │   ├── rules/             (detailed rule files, if any)
+│   │   └── scripts/           (utility scripts, if any)
+│   └── [another-skill]/
+│       └── SKILL.md
+```
+
+**Discovery:** During workspace building (Stage 01), the builder identifies relevant skills by:
+1. Scanning `~/.claude/skills/` and `~/.agents/skills/` for locally installed skills
+2. Searching GitHub for skill repos matching the workspace domain (e.g., "remotion skill", "pptx skill")
+3. Presenting candidates to the user for selection
+
+**Bundling:** Selected skills are copied (local) or cloned (GitHub) into the workspace's `skills/` folder during scaffolding (Stage 03). This makes the workspace self-contained.
+
+**Referencing:** Stage CONTEXT.md files reference skills in their Inputs table:
+
+```
+| Skill | `../../skills/[name]/SKILL.md` | Index, then load rules as needed | [What it provides] |
+```
+
+Skills replace custom reference docs when an official skill covers the same ground. Keep workspace-specific files (design systems, brand config, build conventions) alongside skills, not inside them.
+
+**When NOT to bundle:** Do not bundle skills that are purely about Claude Code itself (e.g., skill-creator, mcp-builder). Only bundle skills that provide domain knowledge the workspace's agents need at runtime.
+
+---
+
+## Pattern 10: Specs Are Contracts
+
+Specification stages define WHAT the output should achieve and WHEN things happen. They do not prescribe HOW to implement. The build stage has creative freedom within the quality floor defined by the design system.
+
+A spec contains:
+- **Beat map** with approximate durations, narration, and mood
+- **Visual philosophy** describing what a muted viewer should understand
+- **Key moments** that MUST land, and why each matters
+- **Audio sync points** mapping narration words to visual events
+- **Color flow** with per-scene dominant color and mood
+
+A spec does NOT contain: frame numbers, component names, pixel positions, spring configs, or prop definitions. These are implementation decisions that belong to the build stage.
+
+---
+
+## Pattern 11: Checkpoints
+
+Creative stages should include at least one checkpoint where the agent pauses and the human steers. The agent completes a full unit of work, presents options or a draft, and the human redirects before the next unit begins. Checkpoints go between process steps, not within them.
+
+Not every stage needs checkpoints. Linear stages (extract, render, validate) often run straight through. Creative stages (writing, design, ideation) benefit from at least one.
+
+The Checkpoints section in a stage CONTEXT.md is a table:
+
+```
+| After Step | Agent Presents | Human Decides |
+|------------|---------------|---------------|
+| [step #] | [what to show] | [what to choose] |
+```
+
+---
+
+## Pattern 12: Stage Audits
+
+Creative and build stages should include an Audit section: a checklist the agent runs after completing the process but before writing to output/. Audits catch quality issues before they propagate downstream. Each check should be specific enough that pass/fail is unambiguous.
+
+Not every stage needs an audit. Data extraction or file conversion stages may not benefit. Creative and build stages almost always do.
+
+The Audit section in a stage CONTEXT.md is a table:
+
+```
+| Check | Pass Condition |
+|-------|---------------|
+| [Check name] | [What "passing" looks like] |
+```
+
+If any check fails, the agent revises before saving to output/.
+
+---
+
+## Pattern 13: Value Validation
+
+Content-producing stages should define what types of value their output can deliver. Before the main creative work begins (ideally at a checkpoint), the agent and human should agree on which value types this specific piece will hit. This prevents "interesting but doesn't DO anything" output.
+
+Value types are workspace-specific. A content workspace might use NOVEL, USABLE, QUESTION-GENERATING, INTERESTING. A course workspace might use TEACHES, PRACTICES, CHALLENGES. The framework is defined once in a reference file and used at every checkpoint.
+
+---
+
+## Pattern 14: Docs Over Outputs
+
+Reference docs (design system, build conventions, skill rules) are the authoritative source for how to build. Previous stage outputs in `output/` folders are artifacts, not templates. Agents should not read other outputs to learn patterns.
+
+This prevents copying from older, lower-quality work and ensures docs remain the single source of truth for quality standards. Early outputs are the worst outputs. If future agents learn from them, quality never improves.
+
+---
+
+## Pattern 15: Shared Constants
+
+Workspaces that produce code should define a constants pattern. Configurable values (colors, fonts, timing, layout) live in shared files that all build outputs import from. The questionnaire populates these files once during onboarding. Change a value once, it updates everywhere.
+
+This is Pattern 5 (Canonical Sources) applied to code values. Without shared constants, the same hex code or font name is hardcoded in every output file. Changing the brand color means a find-and-replace across every file ever built.
+
+For non-code workspaces (content writing, course design), this pattern does not apply. Shared values live in reference docs instead.
+
+---
+
+## Quality Guardrails
+
+- CONTEXT.md files: under 80 lines
+- Reference files: under 200 lines (if longer, split into multiple files)
+- Use plain English. Avoid jargon. If a term needs explaining, it is too specialized.
+- No em dashes anywhere in the repo
+- Every folder that should persist but starts empty gets a `.gitkeep` file
+- Every markdown file should be readable by someone who understands markdown and git basics but does not have a deep engineering background

--- a/skills/meta/procedure-builder/templates/_core/SOURCE.md
+++ b/skills/meta/procedure-builder/templates/_core/SOURCE.md
@@ -1,0 +1,37 @@
+# `_core/` template — provenance
+
+This is a **vendored copy** of the canonical ICM `_core/` directory. It is bundled
+with the `procedure-builder` skill so a fresh ICM workspace can be bootstrapped
+offline and deterministically (no runtime download).
+
+## Source
+
+- Repo: https://github.com/RinDig/Interpreted-Context-Methdology
+- Path: `_core/`
+- Vendored on: 2026-05-07
+- Vendored by: `procedure-builder` Stage 00 (Bootstrap) updates this directory
+  by re-running the curl commands below if a refresh is requested.
+
+## Refresh procedure
+
+```bash
+BASE=https://raw.githubusercontent.com/RinDig/Interpreted-Context-Methdology/main/_core
+TARGET=skills/meta/procedure-builder/templates/_core
+
+curl -sf "$BASE/CONVENTIONS.md" -o "$TARGET/CONVENTIONS.md"
+curl -sf "$BASE/placeholder-syntax.md" -o "$TARGET/placeholder-syntax.md"
+curl -sf "$BASE/templates/questionnaire-template.md" -o "$TARGET/templates/questionnaire-template.md"
+curl -sf "$BASE/templates/stage-context-template.md" -o "$TARGET/templates/stage-context-template.md"
+curl -sf "$BASE/templates/workspace-claude-template.md" -o "$TARGET/templates/workspace-claude-template.md"
+curl -sf "$BASE/templates/workspace-context-template.md" -o "$TARGET/templates/workspace-context-template.md"
+```
+
+Run this only when you've reviewed upstream changes and decided to adopt them.
+Do not auto-update — the canonical version is whatever is committed here.
+
+## Why vendor instead of fetching at runtime
+
+- **Offline / Fargate dispatch** — the skill must work without network access
+- **Determinism** — running `procedure-builder` against the same spec twice must
+  produce the same `_core/` regardless of upstream drift
+- **Auditability** — diffs to `_core/` are visible in the skill's git history

--- a/skills/meta/procedure-builder/templates/_core/placeholder-syntax.md
+++ b/skills/meta/procedure-builder/templates/_core/placeholder-syntax.md
@@ -1,0 +1,130 @@
+# Placeholder Syntax
+
+How the onboarding system works. Workspaces ship with placeholder variables in their markdown files. The onboarding agent replaces these with real content when a user runs `setup`.
+
+---
+
+## Basic Syntax
+
+Placeholders use double braces and SCREAMING_SNAKE_CASE:
+
+```
+{{BRAND_NAME}}
+{{TARGET_AUDIENCE}}
+{{PRIMARY_COLOR}}
+```
+
+These are literal strings in markdown files. They are not code variables. The onboarding agent finds them and replaces them with the user's answers through string substitution.
+
+---
+
+## Replacement Rules
+
+1. The onboarding agent reads `setup/questionnaire.md` for the list of questions
+2. Each question maps to one or more placeholders
+3. Each question specifies which files contain its placeholder
+4. The agent asks the questions conversationally, collecting answers
+5. The agent replaces every instance of each placeholder with the corresponding answer
+6. After all replacements, the agent scans the entire workspace for any remaining `{{` patterns
+7. If any remain, the agent flags them and asks the user for the missing information
+8. Onboarding is complete only when zero placeholders remain
+
+---
+
+## Where Placeholders Can Appear
+
+Placeholders can appear in any markdown file within a workspace:
+- Brand vault files (voice-rules.md, identity.md)
+- Reference files (hook-system.md, design-system.md, etc.)
+- Shared files (platform-specs.md)
+- Stage CONTEXT.md files (only in Inputs table values, not in routing structure)
+
+Placeholders should NOT appear in:
+- CLAUDE.md files (these need to work before onboarding runs)
+- Top-level CONTEXT.md routing tables (these need to work before onboarding runs)
+- The questionnaire.md itself (the questions are the source, not the target)
+
+---
+
+## Conditional Sections
+
+Conditional sections wrap content that gets removed if the user indicates it is not needed.
+
+Syntax:
+
+```markdown
+{{?SECTION_NAME}}
+
+## Section Heading
+
+Content that may or may not be relevant...
+
+{{/SECTION_NAME}}
+```
+
+**Rule: Conditional blocks can only wrap entire sections.** A section means a heading and all content below it, up to the next heading of the same or higher level.
+
+Valid:
+
+```markdown
+{{?VIDEO_PRODUCTION}}
+
+## Video Production Settings
+
+Resolution, frame rate, and export format for your video pipeline.
+
+- Resolution: 1920x1080
+- Frame rate: 30fps
+- Export format: MP4
+
+{{/VIDEO_PRODUCTION}}
+```
+
+Invalid (do not do this):
+
+```markdown
+- Item one
+{{?OPTIONAL_ITEM}}
+- Item two (optional)
+{{/OPTIONAL_ITEM}}
+- Item three
+```
+
+Invalid (do not do this):
+
+```markdown
+The brand voice is {{?FORMAL}}formal and authoritative{{/FORMAL}}
+{{?CASUAL}}casual and conversational{{/CASUAL}}.
+```
+
+Why this rule exists: removing inline content leaves orphaned list markers, broken sentences, or malformed markdown. Wrapping complete sections means removal always produces clean markdown.
+
+---
+
+## Naming Conventions
+
+Use descriptive names: `{{BRAND_NAME}}` not `{{BN}}`.
+
+Group related placeholders with common prefixes:
+- `{{VOICE_DESCRIPTION}}`, `{{VOICE_ADJECTIVES}}`
+- `{{PRIMARY_COLOR}}`, `{{SECONDARY_COLOR}}`, `{{ACCENT_COLOR}}`
+- `{{CONTENT_PILLAR_1}}`, `{{CONTENT_PILLAR_2}}`
+
+Conditional section names should describe what they wrap:
+- `{{?BUILD_STAGE}}` for the build stage section
+- `{{?PILLAR_4}}` for the fourth content pillar
+
+---
+
+## Questionnaire Mapping
+
+The `setup/questionnaire.md` file is the bridge between questions and placeholders. Each question entry specifies:
+
+- The question text (what the agent asks the user)
+- The placeholder(s) it populates
+- The file(s) where those placeholders appear
+- The input type (free text, multiple choice, yes/no)
+- Optional: follow-up questions for vague answers
+- Optional: conditional logic (if answer is X, remove section Y)
+
+See `_core/templates/questionnaire-template.md` for the format.

--- a/skills/meta/procedure-builder/templates/_core/templates/questionnaire-template.md
+++ b/skills/meta/procedure-builder/templates/_core/templates/questionnaire-template.md
@@ -1,0 +1,48 @@
+# Onboarding Questionnaire
+
+<!-- Agent instructions: Read this file when the user types "setup". Ask ALL questions
+     in a single conversational pass. The user should be able to answer everything in one
+     message. Collect answers. Replace placeholders across the specified files. After all
+     replacements, verify no {{PLACEHOLDER}} patterns remain in the workspace. -->
+
+<!-- Questionnaire design rules:
+     1. FLAT STRUCTURE: No category groupings. Just a numbered list of questions.
+     2. ALL AT ONCE: Every question appears in one pass. The user answers in one message.
+     3. SYSTEM-LEVEL ONLY: Questions configure the production system, not a specific run.
+        Per-run details (project name, topic, audience) are collected conversationally
+        at the start of each pipeline run by the entry stage.
+     4. DERIVE, DON'T ASK: If a field can be derived from other answers, the agent fills
+        it in without asking. List derived fields under the question they depend on.
+     5. SENSIBLE DEFAULTS: Every question should have a default or example so the user
+        can skip what they don't care about.
+     6. ASK ONCE, NEVER AGAIN: After setup, the user should never be asked these questions
+        again. The answers are baked into the workspace files permanently.
+     7. EXAMPLES OVER DESCRIPTIONS: For voice/style questions, ask for concrete examples
+        (sentences that sound right, sentences that sound wrong, specific error patterns)
+        rather than abstract descriptions. Examples are pattern-matchable. Descriptions
+        require interpretation and produce weaker constraints. -->
+
+### Q1: [Question text]
+- Placeholder: `{{PLACEHOLDER_NAME}}`
+- Files: `path/to/file1.md`, `path/to/file2.md`
+- Type: free text
+- Default: [Default value if user wants to skip]
+
+### Q2: [Question text]
+- Placeholder: `{{PLACEHOLDER_NAME}}`
+- Files: `path/to/file.md`
+- Type: selection
+- Options: Option A, Option B, Option C
+
+### Q3: [Question about an optional feature -- yes/no]
+- Type: yes/no
+- If NO: Remove `stages/0N-name/` entirely
+- If YES: Keep it
+
+---
+
+## After Onboarding
+
+[Tell the user what was configured and where to start.]
+
+After all replacements, scan the entire workspace for remaining `{{` patterns. If any remain, ask for the missing info.

--- a/skills/meta/procedure-builder/templates/_core/templates/stage-context-template.md
+++ b/skills/meta/procedure-builder/templates/_core/templates/stage-context-template.md
@@ -1,0 +1,68 @@
+# [Stage Name]
+
+[One sentence: what this stage does.]
+
+## Inputs
+
+<!-- List every file the agent needs. Be specific about which sections. -->
+
+| Source | File/Location | Section/Scope | Why |
+|--------|--------------|---------------|-----|
+| Previous stage | `../0N-prev/output/artifact.md` | Full file | The artifact to work from |
+| Reference | `references/example.md` | "Relevant Section" | What it provides |
+
+## Process
+
+<!-- Numbered steps. Each step is one concrete action. Be specific enough that
+     two different agents following these steps would produce structurally similar
+     outputs.
+
+     Too vague: "Write the script"
+     Good: "Write the full script in one pass, then audit against the voice
+            hard constraints and value brief"
+
+     Too vague: "Generate ideas"
+     Good: "Propose 3-5 concept angles, each as a single sentence. Tag each
+            with its value type and format." -->
+
+1. Read the input artifact from the previous stage
+2. [Step two]
+3. [Step three]
+4. Save to output/
+
+## Checkpoints
+
+<!-- Points where the agent pauses for human input before continuing.
+     Not every stage needs checkpoints. Linear stages (extract, render, validate)
+     often run straight through. Creative stages (writing, design, ideation)
+     benefit from at least one.
+
+     Format: after which process step, what the agent presents, what the human decides.
+     Delete this section if the stage runs straight through. -->
+
+| After Step | Agent Presents | Human Decides |
+|------------|---------------|---------------|
+| [step #] | [what options/output to show] | [what direction to choose] |
+
+## Audit
+
+<!-- Quality checks before the output is considered done. The agent runs these
+     after completing the process steps. If any check fails, revise before saving.
+
+     Not every stage needs an audit. Data extraction or file conversion stages
+     may not benefit. Creative and build stages almost always do.
+     Delete this section if no audit applies. -->
+
+| Check | Pass Condition |
+|-------|---------------|
+| [Check name] | [What "passing" looks like] |
+
+## Outputs
+
+<!-- What this stage produces and where it goes. -->
+
+| Artifact | Location | Format |
+|----------|----------|--------|
+| [Name] | `output/[slug]-[type].md` | [Description of the format] |
+
+<!-- Target: keep this file under 80 lines. -->

--- a/skills/meta/procedure-builder/templates/_core/templates/workspace-claude-template.md
+++ b/skills/meta/procedure-builder/templates/_core/templates/workspace-claude-template.md
@@ -1,0 +1,48 @@
+# [Workspace Name]
+
+[One sentence: what this workspace does.]
+
+## Folder Map
+
+```
+[workspace-name]/
+├── CLAUDE.md          (you are here)
+├── CONTEXT.md         (start here for task routing)
+├── setup/             (onboarding questionnaire)
+├── skills/            (bundled Claude skills for domain knowledge)
+├── [context-folder]/  (shared context files)
+├── stages/
+│   ├── 01-[name]/     ([brief description])
+│   ├── 02-[name]/     ([brief description])
+│   └── 03-[name]/     ([brief description])
+└── shared/            (cross-stage reference files)
+```
+
+## Triggers
+
+| Keyword | Action |
+|---------|--------|
+| `setup` | Run onboarding questionnaire |
+| `status` | Show pipeline completion for all stages |
+
+## Routing
+
+| Task | Go To |
+|------|-------|
+| [Task type 1] | `stages/01-[name]/CONTEXT.md` |
+| [Task type 2] | `stages/02-[name]/CONTEXT.md` |
+| [Task type 3] | `stages/03-[name]/CONTEXT.md` |
+
+## What to Load
+
+<!-- Map each task to its minimal file set. Loading more files dilutes quality.
+     The context window is working memory, not storage. -->
+
+| Task | Load These | Do NOT Load |
+|------|-----------|-------------|
+| [Task 1] | [minimal file list] | [what to skip and why] |
+| [Task 2] | [minimal file list] | [what to skip and why] |
+
+## Stage Handoffs
+
+Each stage writes its output to its own `output/` folder. The next stage reads from there. If you edit an output file, the next stage picks up your edits.

--- a/skills/meta/procedure-builder/templates/_core/templates/workspace-context-template.md
+++ b/skills/meta/procedure-builder/templates/_core/templates/workspace-context-template.md
@@ -1,0 +1,19 @@
+# [Workspace Name]
+
+[One sentence: what this workspace covers.]
+
+## Task Routing
+
+| Task Type | Go To | Description |
+|-----------|-------|-------------|
+| [Task 1] | `stages/01-[name]/CONTEXT.md` | [What this stage does] |
+| [Task 2] | `stages/02-[name]/CONTEXT.md` | [What this stage does] |
+| [Task 3] | `stages/03-[name]/CONTEXT.md` | [What this stage does] |
+
+## Shared Resources
+
+| Resource | Location | Contains |
+|----------|----------|----------|
+| [Context folder] | `[folder]/CONTEXT.md` | [What it routes to] |
+| [Shared files] | `shared/` | [What cross-stage files live here] |
+| [Skill name] | `skills/[name]/SKILL.md` | [What domain knowledge this skill provides] |


### PR DESCRIPTION
## Summary

The procedure-builder skill assumed `_core/` already existed at the repo root, but a fresh ICM workspace doesn't have it. This change makes the skill self-bootstrapping.

- **Vendor `_core/`** into `templates/_core/` (sourced once from `RinDig/Interpreted-Context-Methdology` — provenance + refresh in `SOURCE.md`). Keeps the skill offline-deterministic for Fargate dispatch and avoids upstream drift.
- **Add Stage 00 (Bootstrap `_core/`)** to `SKILL.md`. Runs on every invocation; no-op if `_core/` is present. If missing, copies the vendored template to repo root and audits. Stops the procedure if audit fails.
- Bumps pipeline description from five-stage to six-stage. The five ICM workspace-builder stages are unchanged.

Motivated by setting up the Lexgo-cl/marketing repo as an ICM workspace per fellowship-dev/pylot#371.

## Test plan

- [ ] Install via \`npx skills add fellowship-dev/dogfooded-skills --skill procedure-builder\` into a fresh repo with no \`_core/\`
- [ ] Run \`/procedure-builder some-spec.md\` and verify Stage 00 creates \`_core/\` at the repo root with all 4 expected files + \`SOURCE.md\`
- [ ] Re-run on the same repo and verify Stage 00 reports \`already present, skipping\`
- [ ] Check \`_core/templates/\` contains the 4 ICM templates (stage-context, questionnaire, workspace-claude, workspace-context)
- [ ] Verify the byte-for-byte audit catches a corrupted \`_core/\` (manually edit one file, re-run, expect FAIL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)