### PR TITLE
feat(skills): pylot-onboarding — checklist-driven worker setup for new repos (#57)

### DIFF
--- a/reports/2026-05-22-speckit-dogfooded-skills-issue-57.md
+++ b/reports/2026-05-22-speckit-dogfooded-skills-issue-57.md
@@ -1,0 +1,25 @@
+# Pre-flight Report — dogfooded-skills issue #57
+
+**Source issue:** https://github.com/fellowship-dev/dogfooded-skills/issues/57
+**Date:** 2026-05-22
+**Title:** feat(skills): pylot-onboarding — checklist-driven worker setup for new repos
+
+## Issue Summary
+
+Onboarding Lexgo-cl/lexgo-website to the Pylot booster-pack crew burned 5+ hours because an `infra.ops` job (1779423226) built the app's Next.js Dockerfile and pushed it to the Pylot worker ECR repo. Symptoms were non-obvious: `input_tokens: null`, `exit_code: 1`, 60–120s runtimes across all 4 operators.
+
+The fix is a new `pylot-onboarding` skill encoding the correct procedure and all failure modes.
+
+## Deliverables
+
+- `skills/ops/pylot-onboarding/SKILL.md` — invocation docs with 5-step summary
+- `skills/ops/pylot-onboarding/docs/checklist.md` — 5-step onboarding procedure
+- `skills/ops/pylot-onboarding/docs/canary.md` — 3 failure mode diagnosis + fix
+
+## Repo Structure Decision
+
+Issue spec shows `skills/pylot-onboarding/` as sibling to `pylot-api/` and `vercel-deploy/`. Actual repo places all operational skills under `skills/ops/`. Placed new skill at `skills/ops/pylot-onboarding/` to match existing convention (vercel-deploy, fly-io, popsicle all live under `skills/ops/`).
+
+## No Questions / Blockers
+
+Issue body is exhaustive and contains all content needed. No clarification required.

--- a/skills/ops/pylot-onboarding/SKILL.md
+++ b/skills/ops/pylot-onboarding/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: pylot-onboarding
+description: Checklist-driven worker setup for onboarding a new repo to the Pylot booster-pack crew. Encodes the correct 5-step procedure and failure-mode diagnosis to prevent trial-and-error.
+user-invocable: true
+allowed-tools: Read, Bash
+---
+
+# pylot-onboarding
+
+Onboard a repo to the Pylot booster-pack crew in one session, without trial-and-error.
+
+**Why this skill exists:** Onboarding Lexgo-cl/lexgo-website burned 5+ hours because `infra.ops` silently built the app's Next.js Dockerfile and pushed it to the Pylot worker ECR repo. Symptoms were non-obvious (`input_tokens: null`, `exit_code: 1`, 60–120s runtimes). This skill encodes the correct procedure and all known failure modes so the next repo doesn't repeat that.
+
+## Invocation
+
+```
+/pylot-onboarding <org/repo>
+```
+
+Example: `/pylot-onboarding Lexgo-cl/lexgo-website`
+
+## 5-Step Summary
+
+| Step | Name | What happens |
+|------|------|-------------|
+| 1 | [Pre-flight](docs/checklist.md#step-1--pre-flight-verify-crewyml) | Read `crew.yml` — confirm `worker_images` points to the correct ECR path, not the app Dockerfile |
+| 2 | [Build worker images](docs/checklist.md#step-2--build-worker-images-with-ensure-workersh) | Dispatch `ensure-worker.sh` via `infra.ops` from `fellowship-dev/pylot` for all four operator families |
+| 3 | [Operator canary](docs/checklist.md#step-3--operator-canary-run) | Dispatch a minimal mission to each operator; confirm `status: done`, `exit_code: 0`, non-null `input_tokens` |
+| 4 | [Load keychains](docs/checklist.md#step-4--load-keychains) | Load `booster-pack` and `booster-pack/<org>%2F<repo>` keychains |
+| 5 | [Seed CLAUDE.md](docs/checklist.md#step-5--seed-claudemd-with-pylot-ops-section) | Dispatch `booster-pack.cto` to add a `## Pylot Ops` section documenting operators, keychains, and CI commands |
+
+**Do not proceed past Step 2 until the canary signals are clean.** If any operator fails with `input_tokens: null` or `exit_code: 1` in under 120s, see [docs/canary.md](docs/canary.md) before continuing.
+
+## Critical Rules
+
+1. **Never dispatch booster-pack missions until Step 2 exits 0 with non-null `input_tokens`.**
+2. **Step 2 must dispatch to `infra.ops` in `fellowship-dev/pylot` — never build from anything in the target repo.**
+3. **Each operator has its own ECS task definition family — fixing one does not fix the others.**
+4. **`input_tokens: null` means the container crashed before Claude ran — do not retry the mission, fix the image first.**

--- a/skills/ops/pylot-onboarding/docs/canary.md
+++ b/skills/ops/pylot-onboarding/docs/canary.md
@@ -1,0 +1,138 @@
+# Diagnosing Worker Image Failures
+
+Use this doc when a booster-pack mission returns unexpected signals. All three root causes produce similar surface symptoms — the signal table below distinguishes them.
+
+---
+
+## Failure Signal Table
+
+| Signal | Value | Meaning |
+|--------|-------|---------|
+| `input_tokens` | `null` | Container crashed before Claude ran — the image is broken |
+| `input_tokens` | Real number | Claude ran — failure is in the task, not the image |
+| `exit_code` | `1` + duration ~60–120s | Worker image is broken (wrong Docker image or crash on boot) |
+| `exit_code` | `1` + duration > 5 min | Task failed after Claude ran — check mission logs |
+| `status` | `done` | Job completed (check `exit_code` and `input_tokens` separately) |
+| `status` | `failed` | Job did not complete — likely infra-level failure |
+
+**The critical discriminator is `input_tokens`.** Null = container crashed before Claude ran. Non-null = Claude ran; the failure is in the mission content, not the image.
+
+---
+
+## Root Cause #1 — Wrong Dockerfile built
+
+A previous `infra.ops` job built the target repo's **app Dockerfile** (e.g., a Next.js or Rails Dockerfile) and pushed it to the `pylot-worker-*` ECR repository. The container starts, fails to launch a Claude agent, and exits in ~60–120s.
+
+### Diagnosis
+
+| Signal | Value |
+|--------|-------|
+| `input_tokens` | `null` |
+| `exit_code` | `1` |
+| Duration | 60–120s |
+| Operator | One or more (whichever had `ensure-worker.sh` run against the wrong Dockerfile) |
+
+To confirm, check the ECR image tag timestamp against the `infra.ops` job that ran most recently. If the image was pushed at the same time as an app build job, this is the cause.
+
+### Fix
+
+Re-run `ensure-worker.sh` from `fellowship-dev/pylot` via `infra.ops` for the affected operator family:
+
+```
+Dispatch to: infra.ops
+Repo: fellowship-dev/pylot
+Task: Run scripts/ensure-worker.sh for <org/repo>, operator family: <operator>.
+      This rebuilds the correct Pylot worker image and pushes it to ECR.
+```
+
+Do **not** try to patch the ECS task definition manually — `ensure-worker.sh` handles the full image build, push, and task definition update.
+
+After the job completes (exit 0), re-run the canary mission for the affected operator.
+
+---
+
+## Root Cause #2 — Per-operator task def not patched
+
+`booster-pack.cto` works (or one operator works) but `booster-pack.dev`, `.qa`, or `.designer` still fail with `input_tokens: null`. This happens when `ensure-worker.sh` was run for only one operator family, leaving the others pointing at a stale or wrong image.
+
+### Diagnosis
+
+| Signal | Value |
+|--------|-------|
+| `input_tokens` | `null` on `.dev`, `.qa`, or `.designer` |
+| `input_tokens` | Real number on `.cto` (or whichever was fixed) |
+| `exit_code` | `1` on the failing operators |
+| Duration | 60–120s on the failing operators |
+
+Each operator maps to its own ECS task definition family:
+- `pylot-worker-<org>-<repo>-cto`
+- `pylot-worker-<org>-<repo>-dev`
+- `pylot-worker-<org>-<repo>-qa`
+- `pylot-worker-<org>-<repo>-designer`
+
+Updating one task definition does not propagate to the others.
+
+### Fix
+
+Run `ensure-worker.sh` for each failing operator family independently:
+
+```
+Dispatch to: infra.ops
+Repo: fellowship-dev/pylot
+Task: Run scripts/ensure-worker.sh for <org/repo>.
+      Target each failing operator family separately:
+        pylot-worker-<org>-<repo>-dev
+        pylot-worker-<org>-<repo>-qa
+        pylot-worker-<org>-<repo>-designer
+```
+
+Run the canary for each operator after the job completes. Do not assume that fixing two fixes the third — verify each one.
+
+---
+
+## Root Cause #3 — Missing `crew.yml`
+
+`infra.ops` fails when running `ensure-worker.sh` because the target repo has no `crew.yml` defining the `worker_images` block. Without it, `ensure-worker.sh` cannot determine which ECR repositories to build for.
+
+### Diagnosis
+
+| Signal | Value |
+|--------|-------|
+| `infra.ops` job | `exit_code: 1` early in the run |
+| Error message | "crew.yml not found" or "worker_images undefined" |
+| `input_tokens` | Non-null (infra.ops itself ran; it was the `ensure-worker.sh` script that failed) |
+
+This failure happens at Step 2 of the checklist, not during a booster-pack canary.
+
+### Fix
+
+Add `crew.yml` to the target repo with the correct `worker_images` block:
+
+```yaml
+worker_images:
+  cto: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-cto:latest
+  dev: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-dev:latest
+  qa: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-qa:latest
+  designer: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-designer:latest
+```
+
+Replace `<org>`, `<repo>`, and the AWS account ID with the correct values. Commit and push the file, then re-run Step 2 of the [onboarding checklist](checklist.md#step-2--build-worker-images-with-ensure-workersh).
+
+---
+
+## Quick Decision Tree
+
+```
+Canary fails →
+  input_tokens null?
+    yes → duration ~60–120s?
+      yes → Root Cause #1 or #2 (wrong image)
+        All operators failing? → Root Cause #1 (wrong Dockerfile built for all)
+        Only some operators?  → Root Cause #2 (per-operator task def not patched)
+      no  → infra-level failure; check Fargate task logs
+    no  → Claude ran; check mission output for task-level error
+        → Not an image issue
+
+ensure-worker.sh fails →
+  crew.yml missing or no worker_images? → Root Cause #3
+```

--- a/skills/ops/pylot-onboarding/docs/checklist.md
+++ b/skills/ops/pylot-onboarding/docs/checklist.md
@@ -1,0 +1,141 @@
+# Pylot Onboarding Checklist
+
+5-step procedure for wiring a new repo to the Pylot booster-pack crew. Follow steps in order — each step is a gate.
+
+---
+
+## Step 1 — Pre-flight: verify `crew.yml`
+
+Read `crew.yml` from the target repo and confirm it exists and defines a `worker_images` block pointing to the correct Pylot worker ECR repository — **not** the app's own Dockerfile or image.
+
+```bash
+# Read crew.yml from the target repo (adjust path as needed)
+cat crew.yml
+```
+
+Look for a block like:
+
+```yaml
+worker_images:
+  cto: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-cto:latest
+  dev: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-dev:latest
+  qa: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-qa:latest
+  designer: 123456789.dkr.ecr.us-east-1.amazonaws.com/pylot-worker-<org>-<repo>-designer:latest
+```
+
+**Stop here if `crew.yml` is missing or `worker_images` is absent or points to the wrong image.** Add or fix it before proceeding. See [canary.md §Root cause #3](canary.md#root-cause-3--missing-crewyml) for diagnosis when `infra.ops` fails because `crew.yml` is absent.
+
+---
+
+## Step 2 — Build worker images with `ensure-worker.sh`
+
+**This is the most critical step.** The Pylot worker images must be built from `fellowship-dev/pylot`'s `scripts/ensure-worker.sh`, not from anything in the target repo.
+
+**Dispatch to `infra.ops` — never to `infra.dev` (it does not have Docker/ECR access).**
+
+```
+Dispatch to: infra.ops
+Repo: fellowship-dev/pylot
+Task: Run scripts/ensure-worker.sh for <org/repo>.
+      Build all four operator families:
+        pylot-worker-<org>-<repo>-cto
+        pylot-worker-<org>-<repo>-dev
+        pylot-worker-<org>-<repo>-qa
+        pylot-worker-<org>-<repo>-designer
+```
+
+Wait for the job to complete. Verify:
+- `status: done`
+- `exit_code: 0`
+- `input_tokens` is a real number (not null)
+- Duration > 30s (under 30s = container crashed before Claude ran)
+
+**Do not proceed to Step 3 until all four operator families report clean signals.**
+
+Per-operator isolation — each operator is a separate ECS task definition family:
+- `pylot-worker-<org>-<repo>-cto`
+- `pylot-worker-<org>-<repo>-dev`
+- `pylot-worker-<org>-<repo>-qa`
+- `pylot-worker-<org>-<repo>-designer`
+
+Fixing one does **not** fix the others. Run `ensure-worker.sh` for all four.
+
+---
+
+## Step 3 — Operator canary run
+
+For each of the four operators, dispatch a minimal mission and verify the signals:
+
+```
+Dispatch to: booster-pack.<operator>   (cto | dev | qa | designer)
+Repo: <org/repo>
+Task: Canary check — report the current git HEAD commit hash and confirm you can read the repo.
+```
+
+Expected signals for a healthy operator:
+
+| Signal | Expected value |
+|--------|---------------|
+| `status` | `done` |
+| `exit_code` | `0` |
+| `input_tokens` | Real number (e.g. 4821) |
+| Duration | > 30s |
+
+If any operator returns `input_tokens: null` or `exit_code: 1` with duration < 120s, the worker image is broken. Stop and re-run Step 2 for that specific operator family. See [canary.md](canary.md) for full diagnosis.
+
+---
+
+## Step 4 — Load keychains
+
+Two keychains are always required for booster-pack missions:
+
+| Keychain | Contents |
+|----------|---------|
+| `booster-pack` | `GH_TOKEN`, `FLY_TOKEN`, `VERCEL_TOKEN` |
+| `booster-pack/<org>%2F<repo>` | Repo-specific secrets (URL-encoded slash) |
+
+Load both via the Pylot admin before dispatching any real missions:
+
+```bash
+# Example using the Pylot API
+curl -X POST "$PYLOT_DISPATCH_URL/keychains/load" \
+  -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"keychain": "booster-pack", "repo": "<org>/<repo>"}'
+
+curl -X POST "$PYLOT_DISPATCH_URL/keychains/load" \
+  -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"keychain": "booster-pack/<org>%2F<repo>", "repo": "<org>/<repo>"}'
+```
+
+Verify the keychain contents are present by running a canary mission that reads `$GH_TOKEN` (should be non-empty).
+
+---
+
+## Step 5 — Seed CLAUDE.md with Pylot Ops section
+
+Dispatch `booster-pack.cto` to add a `## Pylot Ops` section to the repo's `CLAUDE.md` documenting the available operators, required keychains, and known CI/deploy commands.
+
+```
+Dispatch to: booster-pack.cto
+Repo: <org/repo>
+Task: Add a "## Pylot Ops" section to CLAUDE.md documenting:
+      - Available operators: cto, dev, qa, designer
+      - Required keychains: booster-pack, booster-pack/<org>%2F<repo>
+      - Known CI command (from package.json or Makefile)
+      - Known deploy command (from fly.toml, vercel.json, or equivalent)
+      Open a PR for this change.
+```
+
+Once the PR is merged, the repo is fully onboarded. All four operators can read CLAUDE.md on any future mission and know how to operate in the repo without additional context.
+
+---
+
+## Completion Checklist
+
+- [ ] `crew.yml` exists with correct `worker_images` ECR paths
+- [ ] All four worker image families built successfully (exit 0, non-null `input_tokens`)
+- [ ] Canary missions pass for all four operators
+- [ ] Both keychains loaded: `booster-pack` and `booster-pack/<org>%2F<repo>`
+- [ ] `CLAUDE.md` updated with `## Pylot Ops` section


### PR DESCRIPTION
## Summary

- Adds `skills/ops/pylot-onboarding/` skill with SKILL.md, docs/checklist.md, and docs/canary.md
- Encodes the correct 5-step procedure for onboarding a new repo to the Pylot booster-pack crew
- Documents all 3 worker image failure modes with diagnosis signal tables and fixes

Closes #57

## Motivation

The Lexgo-cl/lexgo-website onboarding (2026-05-22) burned 5+ hours because an `infra.ops` job silently built the app's Next.js Dockerfile instead of the Pylot worker image, breaking all 4 operators. Symptoms (`input_tokens: null`, `exit_code: 1`, 60–120s runtimes) don't point to the root cause without knowing the system. This skill encodes the procedure so the next repo doesn't repeat the same failure.

## Files Added

| File | Purpose |
|------|---------|
| `skills/ops/pylot-onboarding/SKILL.md` | Invocation docs (`/pylot-onboarding <org/repo>`) with 5-step summary linking to docs/ |
| `skills/ops/pylot-onboarding/docs/checklist.md` | Full 5-step onboarding procedure: pre-flight `crew.yml` check, `ensure-worker.sh` build, operator canary, keychain load, CLAUDE.md seed |
| `skills/ops/pylot-onboarding/docs/canary.md` | Diagnosis for all 3 failure modes with signal tables and step-by-step fixes |

## Test plan

- [ ] Skill loads correctly via `npx skills add fellowship-dev/dogfooded-skills/skills/ops/pylot-onboarding`
- [ ] SKILL.md invocation section matches actual Pylot dispatch pattern
- [ ] `docs/checklist.md` covers all 5 steps with correct ECR naming convention (`pylot-worker-<org>-<repo>-<operator>`)
- [ ] `docs/canary.md` covers all 3 failure modes: wrong Dockerfile, per-operator task def not patched, missing `crew.yml`
- [ ] Running `/pylot-onboarding` on a fresh repo with an existing `crew.yml` completes without trial-and-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)