### PR TITLE
feat(ops): add weekly-plan skill — roadmap deep-dive + owner-leverage re-rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Skills for CI, deployment, operations, and evidence workflows.
 | [`ops/setup-github`](skills/ops/setup-github/) | Set up GitHub Actions workflows, labels, and project board |
 | [`ops/daily-report`](skills/ops/daily-report/) | Standard format for daily/rollcall team reports |
 | [`ops/write-report`](skills/ops/write-report/) | Write a mission report to reports/ — resolves paths, generates timestamps, posts to Quest |
-| [`ops/weekly-plan`](skills/ops/weekly-plan/) | Interactive weekly roadmap session (CC / pylot chat) — ranks by metrics+momentum+leverage, asks the owner's perceived priorities, deep-triages, slices epics into hourly-sized chunks, writes goals, and activates/tunes the hourly auto-pylot |
+| [`ops/weekly-plan`](skills/ops/weekly-plan/) | Interactive weekly planning session for ONE team (CC / pylot chat) — plan-vs-actual scorecard, batched recommendation-first questionnaire, anti-ghost triage, agent-ready epic slices, goals with done-conditions + expiring focus block, budget + hourly auto-pylot tuning. Run once per team, sequentially |
 
 ## Namespace Convention
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Skills for CI, deployment, operations, and evidence workflows.
 | [`ops/setup-github`](skills/ops/setup-github/) | Set up GitHub Actions workflows, labels, and project board |
 | [`ops/daily-report`](skills/ops/daily-report/) | Standard format for daily/rollcall team reports |
 | [`ops/write-report`](skills/ops/write-report/) | Write a mission report to reports/ — resolves paths, generates timestamps, posts to Quest |
+| [`ops/weekly-plan`](skills/ops/weekly-plan/) | Weekly roadmap deep-dive — deep-triages the backlog, re-ranks by owner leverage, batches open-questions into one decision digest, proposes goal edits. Shapes the queue the hourly auto-pylot executes |
 
 ## Namespace Convention
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Skills for CI, deployment, operations, and evidence workflows.
 | [`ops/setup-github`](skills/ops/setup-github/) | Set up GitHub Actions workflows, labels, and project board |
 | [`ops/daily-report`](skills/ops/daily-report/) | Standard format for daily/rollcall team reports |
 | [`ops/write-report`](skills/ops/write-report/) | Write a mission report to reports/ — resolves paths, generates timestamps, posts to Quest |
-| [`ops/weekly-plan`](skills/ops/weekly-plan/) | Weekly roadmap deep-dive — deep-triages the backlog, re-ranks by owner leverage, batches open-questions into one decision digest, proposes goal edits. Shapes the queue the hourly auto-pylot executes |
+| [`ops/weekly-plan`](skills/ops/weekly-plan/) | Interactive weekly roadmap session (CC / pylot chat) — ranks by metrics+momentum+leverage, asks the owner's perceived priorities, deep-triages, slices epics into hourly-sized chunks, writes goals, and activates/tunes the hourly auto-pylot |
 
 ## Namespace Convention
 

--- a/skills/ops/weekly-plan/SKILL.md
+++ b/skills/ops/weekly-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weekly-plan
-description: Interactive weekly roadmap session for a Pylot team (run in a Claude Code or pylot chat session — NOT headless). Pulls goals + backlog, ranks candidates by metrics + momentum + leverage, asks the owner for their perceived priorities and reconciles, deep-triages to kill ghosts, decomposes epics into hourly-sized testable+deployable slices, writes the reconciled goals, and activates/tunes the hourly auto-pylot. It is the thinking session that shapes what the hourly then executes.
-argument-hint: "org/repo [team]"
+description: Interactive weekly planning session for ONE Pylot team (run in a Claude Code or pylot chat session — NOT headless). Opens with a plan-vs-actual scorecard, ranks candidates by metrics + momentum + leverage, asks the owner everything as one batched recommendation-first questionnaire, deep-triages to kill ghosts, decomposes epics into agent-ready hourly-sized slices, writes goals with binary done-conditions and a dated focus block, sets the team's budget, and activates/tunes the hourly auto-pylot. Run once per team, sequentially. It is the thinking session that shapes what the hourly then executes.
+argument-hint: "team [org/repo]"
 user-invocable: true
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
@@ -10,106 +10,183 @@ allowed-tools: Read, Write, Bash, Glob, Grep
 
 The hourly `auto-pylot` is a tight executor: it triages cheaply and dispatches the top 1–3 issues. It can't afford a deep roadmap dive every hour, and it has no human to ask. `weekly-plan` is the **interactive** counterpart you run **with a person in the loop** — in a Claude Code session or a pylot chat session — to set direction for the week. It shapes the backlog and the goals; the hourly executes them.
 
-**This is not a cron.** It asks the owner questions and waits for answers, so it only runs where a human can respond. There is **no Telegram, no push** — every question and the final digest are presented **in-session**.
+**This is not a cron.** It asks the owner questions and waits for answers, so it only runs where a human can respond. There is **no push channel** — every question and the final digest are presented **in-session**.
 
-**Division of labor:** weekly-plan *shapes* (rank, ask, reconcile, triage, decompose, write goals, activate the hourly). The hourly *executes* (dispatch). One clean kill beats five grazing shots.
+**One team per session.** Run it once per team, sequentially (product teams first, the platform team last, so the platform plan can absorb what the product sessions surfaced). Each session mutates ONLY its own team; cross-team data is read-only context.
+
+**Division of labor:** weekly-plan *shapes* (score, rank, ask, reconcile, triage, decompose, write goals, set budget, activate the hourly). The hourly *executes* (dispatch). One clean kill beats five grazing shots.
 
 ## When to Use
-- The owner opens a CC or pylot-chat session to plan the week / set direction before turning the hourly loose.
+- The owner opens a CC or pylot-chat session to plan a team's week before turning the hourly loose.
 - The backlog feels stale, mislabeled, or unfocused and the goals need a reset.
 - After a big merge wave, to re-aim the hourly.
 
 ## Invocation
 ```
-/weekly-plan org/repo [team]      # e.g. /weekly-plan fellowship-dev/pylot infra  (team defaults to infra)
+/weekly-plan team [org/repo]      # e.g. /weekly-plan infra — repo arg optionally narrows to one of the team's repos
 ```
 
 ## Environment
-In a session these are already set (operator/chat boot); for a local run, source the ops env.
 ```bash
-export REPO="${1:?usage: /weekly-plan org/repo [team]}"; export TEAM="${2:-infra}"
-: "${GH_TOKEN:?}"; : "${PYLOT_DISPATCH_TOKEN:?}"; : "${PYLOT_API_URL:?}"
+export TEAM="${1:?usage: /weekly-plan team [org/repo]}"; export REPO_FILTER="${2:-}"
+: "${PYLOT_DISPATCH_TOKEN:?}"
+PYLOT_API="${PYLOT_API:-${PYLOT_API_URL:-${PYLOT_GATEWAY_URL:?set PYLOT_API or PYLOT_GATEWAY_URL}}}"
 GW(){ curl -sS -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" "$@"; }
 ```
+**GitHub auth — never require a static `GH_TOKEN`.** In an operator or pylot-chat session, auth is already wired via the platform's GitHub App installation tokens (`git-credential-pylot`; `gh` works for every org the App installation covers). In a local Claude Code session, use the identity `gh auth status` already has, routed per target org. If `gh` can't read a team repo, stop and say which org needs access — don't ask for a PAT.
+
+## SESSION BUDGET — the owner's time is the scarcest resource
+- Target **≤30 minutes of owner attention**. ALL research happens BEFORE the first question.
+- Ask everything as **ONE batched questionnaire, ≤10 decisions, recommendation-first**: each item is "Recommendation: X, because Y. Alternatives: Z. Pick 1/2/3." The owner taps numbers; they may bulk-accept ("go with your picks").
+- Any topic needing more than 2 exchanges → tag it `[NEEDS CLARIFICATION]` on the issue, park it, and ship the plan without it.
+- Individually confirm only destructive or irreversible calls: issue closes, budget cuts, cron flips.
 
 ---
 
 ## PRIME DIRECTIVE — research before you promote
 Before you rank, promote, or decompose ANY issue, research it **and its linked/sibling issues**: read the code, git history, linked PRs, and the thread. Most of a long-lived backlog is stale, partially done, or superseded. **Don't chase ghosts.** The default triage outcome is CLOSE or RE-SCOPE with cited evidence — promotion to the hourly's queue is *earned*.
 
+## Step 0 — Score last week (plan-vs-actual)
+Open the session with how the previous plan actually went. Pull, don't recall:
+```bash
+GW "$PYLOT_API/admin/goals/$TEAM"            # previous "This week's focus" = what was planned
+GW "$PYLOT_API/costs/summary?days=7"         # ALL teams, read-only — portfolio view for budget context
+GW "$PYLOT_API/missions?limit=200"           # filter client-side to agents starting "$TEAM." (no team/date param exists)
+gh pr list --repo "$R" --state merged --limit 50 --json number,title,mergedAt,labels   # per team repo
+```
+Present **exactly four numbers** for `$TEAM`, with a trend arrow vs the prior week, one line:
+1. **Planned vs merged** — focus-block items that produced a merged PR.
+2. **Rework rate** — merged PRs that needed >2 revision rounds.
+3. **Cost per merged PR** — team spend ÷ merged PRs.
+4. **Top failure cause** — from mission reports/ledger, one phrase.
+
+Mission `status` lies (delivered PRs sometimes report `failed`) — score delivery from GitHub, not from mission status. Last week's misses are this week's first triage candidates.
+
 ## Step 1 — Orient (load the ground truth)
 Never plan from titles. Load, for `$TEAM`:
 ```bash
-GW "$PYLOT_API_URL/admin/goals/$TEAM"                 # current goals you're validating against
-GW "$PYLOT_API_URL/missions?status=running"           # in-flight — never re-rank these as unstarted
-GW "$PYLOT_API_URL/crew" | jq '.crews[]|select(.name=="'"$TEAM"'")|{cron,repos}'  # hourly state + scope
+GW "$PYLOT_API/crew" | jq '.crews[]|select(.name=="'"$TEAM"'")|{repos,cron,budget_daily_usd,operators:(.operators|keys)}'
+GW "$PYLOT_API/missions?status=running"      # in-flight — never re-rank these as unstarted
+for R in $REPOS; do GW "$PYLOT_API/admin/playbooks/$R"; done   # per-repo guardrails (branch model, deploy hazards, test cmds)
 ```
-Read `docs/principles.md` if present — goals serve the invariants.
+Scope = the team's full repo list (narrowed by `$REPO_FILTER` if given). Read `docs/principles.md` if present — goals serve the invariants. Playbook guardrails (e.g. "pushing master deploys production") MUST flow into Step 7's goals.
 
 ## Step 2 — Compute the signals (metrics + momentum + leverage)
-Pull real numbers; don't hand-wave "leverage".
+Pull real numbers per repo in scope; don't hand-wave "leverage".
 ```bash
 SINCE=$(date -u -v-10d +%Y-%m-%d 2>/dev/null || date -u -d '10 days ago' +%Y-%m-%d)
 # VELOCITY: how fast is the team closing? (throughput is often NOT the constraint — direction is)
-gh issue list --repo "$REPO" --state closed  --limit 200 --json closedAt  --jq "[.[]|select(.closedAt>\"$SINCE\")]|length"
+gh issue list --repo "$R" --state closed  --limit 200 --json closedAt  --jq "[.[]|select(.closedAt>\"$SINCE\")]|length"
 # MOMENTUM: what's actively moving right now?
-gh issue list --repo "$REPO" --state open --limit 300 --json number,title,updatedAt,labels \
+gh issue list --repo "$R" --state open --limit 300 --json number,title,updatedAt,labels \
   --jq "sort_by(.updatedAt)|reverse|.[:25]|.[]|\"\(.number) \(.updatedAt[0:10]) [\(.labels|map(.name)|join(\",\"))] \(.title)\""
 # METRICS: age, priority label, ready-to-work vs blocked/open-questions, install/usage where it applies.
 ```
 For each candidate score three axes: **leverage** (does it unblock the owner / a daily-use surface?), **momentum** (recently active, already in-flight?), **metrics** (ready vs blocked, age, impact ÷ effort). Flag **mislabeled priority** — a daily-use blocker sitting at P2 is a P0 in disguise.
 
-## Step 3 — Propose a ranking (in-session)
-Present, in the session, a short ranked shortlist with the three signals cited per item, plus: what's **ready** vs **needs re-triage**, and what's already **in-flight**. This is a proposal, not a verdict — it sets up Step 4.
+**Weight by task type.** Verifiable chores, fixes, tests, and docs merge at far higher autonomous rates than features and perf work. Fill most of the hourly's weekly queue with verifiable work; treat features/perf as the scarce items that earn the owner's richest specs in Step 4.
 
-## Step 4 — Ask the owner for their perceived priorities
-Interactively reconcile your data-ranking with the owner's gut. In Claude Code use `AskUserQuestion`; in pylot chat, ask directly and wait. Surface where the data disagrees with the owner's read ("you ranked chat #1, but it's not dispatch-ready — devbox is the cleaner first fuel"). **The owner's call wins**; record the why.
+## Step 3 — Propose the plan (in-session)
+Present a short ranked shortlist with the three signals cited per item, plus: what's **ready** vs **needs re-triage**, what's already **in-flight**, and a **budget proposal** for the week (Step 0's portfolio view: concentrate spend on what's converting — a team whose cost-per-merged-PR doubled loses budget to one that's converting; don't peanut-butter). This is a proposal, not a verdict — it sets up Step 4.
+
+## Step 4 — The questionnaire (one batch, owner wins)
+Reconcile your data-ranking with the owner's gut in **one batched, recommendation-first questionnaire** (SESSION BUDGET rules). In Claude Code use `AskUserQuestion`; in pylot chat, ask directly and wait. Surface where the data disagrees with the owner's read ("you ranked chat #1, but it's not dispatch-ready — devbox is the cleaner first fuel"). **The owner's call wins**; record the why next to each decision.
 
 ## Step 5 — Deep-triage the shortlist (anti-ghost)
 For each promoted candidate, do the research the PRIME DIRECTIVE demands (shallow-clone, read code + history + linked issues). Close done/dup and re-scope partials with a cited comment on the issue. Never close P0/P1.
 
-## Step 6 — Decompose epics into HOURLY-sized slices
+## Step 6 — Decompose epics into AGENT-READY, hourly-sized slices
 A big epic isn't dispatchable. Break each promoted epic into the smallest slices where every slice is:
 1. **independently deliverable** (one PR, no cross-slice barrier),
 2. **testable in staging** on its own, and
-3. **deployable** through develop→staging→prod within roughly **one hourly auto-pylot cycle**.
-File/relabel these `ready-to-work` so the hourly can pick one up, test it, and ship it each hour. Note what was sliced and what's deferred.
+3. **deployable** through the team's pipeline within roughly **one hourly auto-pylot cycle**.
+
+Every issue you file or relabel `ready-to-work` MUST carry the **agent-ready contract** — autonomous completion rates live or die on issue quality:
+- **Done-condition** — binary and machine-checkable ("done when X passes in CI / verified by Y in staging"), written BEFORE dispatch;
+- **Context links** — the code paths, sibling issues, and PRs the agent needs (agents can't absorb mid-task scope changes — front-load everything);
+- **Out-of-scope line** — what NOT to touch;
+- **Task-type label** (chore/fix/test/docs/feature/perf).
+
+Note what was sliced and what's deferred.
 
 ## Step 7 — Write the reconciled goals
-Update `/goals` to match the decision, including a dated **"This week's focus"** block pointing the hourly at the ready, highest-ROI first targets. Show the diff; apply on confirmation.
-```bash
-# after confirmation:
-GW -X PUT "$PYLOT_API_URL/admin/goals/$TEAM" -H "Content-Type: text/plain" --data-binary @goals.new.md
-```
+Goals are the hourly's steering wheel — its triage scores every issue against this exact text, so vague goals make a vague fleet. Write `goals.new.md` in this shape:
+```markdown
+# {Team} Goals
 
-## Step 8 — Activate / tune the hourly
-Bring the auto-pylot cron in line with the plan and, **with the owner's go**, enable it.
+## North Star
+One sentence on what this team is for.
+
+## Guardrails — do NOT
+- The non-negotiables (from playbooks + owner), e.g. branch/deploy rules, forbidden areas, PR/day caps.
+
+## Current goals
+### [P0] Title — done when <binary, verifiable condition>
+### [P1] Title — done when <...>
+
+## This week's focus (expires YYYY-MM-DD)
+Dated, ready, highest-ROI first targets for the hourly. Stale plans steer worse than no plan:
+past the expiry date the hourly should treat this block as void and fall back to safe
+maintenance work (deps, flaky tests) instead of free-styling on old priorities.
+```
+Show the diff against the current goals; **apply only on confirmation**, then record provenance:
 ```bash
-# enable (or adjust schedule) — send the FULL cron array back with auto-pylot enabled:true
-GW -X PATCH "$PYLOT_API_URL/admin/crew/$TEAM" -H "Content-Type: application/json" -d "$(jq -c ...)"
-GW "$PYLOT_API_URL/crew" | jq '.crews[]|select(.name=="'"$TEAM"'").cron'   # verify
+GW -X PUT "$PYLOT_API/admin/goals/$TEAM" -H "Content-Type: text/plain" --data-binary @goals.new.md
+GW -X POST "$PYLOT_API/admin/crew/$TEAM/ledger" -H "Content-Type: application/json" \
+  -d '{"type":"weekly-plan-update","actor":"weekly-plan","summary":"weekly plan written","metadata":{"expires":"YYYY-MM-DD","focus_items":N}}'
+rm -f goals.new.md
+```
+The ledger entry is what next week's Step 0 scores against.
+
+## Step 8 — Set the budget and tune the hourly
+Two mutations, both shown to the owner first, both team-local:
+```bash
+# 1. Budget (from Step 3's approved allocation):
+GW -X PATCH "$PYLOT_API/admin/crew/$TEAM" -H "Content-Type: application/json" -d '{"budget_daily_usd": NN}'
+
+# 2. Cron — read-modify-write; the PATCH replaces the WHOLE array, so never send a partial:
+GW "$PYLOT_API/crew" | jq '.crews[]|select(.name=="'"$TEAM"'").cron' > cron.json
+# edit cron.json: add/enable the auto-pylot entry or adjust its schedule; keep every other entry intact
+GW -X PATCH "$PYLOT_API/admin/crew/$TEAM" -H "Content-Type: application/json" \
+  -d "$(jq -c '{cron: .}' cron.json)"
+GW "$PYLOT_API/crew" | jq '.crews[]|select(.name=="'"$TEAM"'")|{cron,budget_daily_usd}'   # verify
+rm -f cron.json
 ```
 
 ## Step 9 — Session summary (in-session, no push)
-Present in the session: the ranking + the three signals, what was triaged (closed/re-scoped, with refs), the **hourly-ready queue** (top first), the epic slices created, the decisions captured, the goals diff, and the final auto-pylot state (enabled? schedule? first focus?).
+Present in the session: the Step 0 scorecard, the ranking + the three signals, what was triaged (closed/re-scoped, with refs), the **hourly-ready queue** (top first), the epic slices created, the decisions captured (with the owner's whys), the goals diff, the budget, and the final auto-pylot state (enabled? schedule? first focus?).
+
+Optionally — with the owner's go — dispatch the single top ready item so the week starts now. The task MUST use an explicit `/skill` prefix or it fails at operator boot:
+```bash
+GW -X POST "$PYLOT_API/dispatch" -H "Content-Type: application/json" \
+  -d '{"agent":"'"$TEAM"'.lead","repo":"org/repo","task":"Run /speckit-runner on org/repo#123 — title"}'
+```
 
 ---
 
 ## Boundaries
 - **Interactive only** — needs a human to answer; never run headless/cron.
-- **Shapes, doesn't mass-dispatch** — respects max-3-concurrent; at most dispatches the single top ready item.
-- **Never** closes P0/P1, rewrites goals, or flips the cron without explicit owner confirmation.
+- **One team per session** — mutates only `$TEAM`'s goals/budget/cron; other teams' data is read-only context.
+- **Shapes, doesn't mass-dispatch** — respects the hourly's concurrency cap; at most dispatches the single top ready item (Step 9, explicit `/skill` task).
+- **Never** closes P0/P1, rewrites goals, sets budgets, or flips the cron without explicit owner confirmation.
 
 ## Anti-patterns
 - Ranking by the `P*` label instead of the three signals — the point is to catch mislabeling.
 - Hand-waving "leverage" without pulling velocity/momentum numbers.
+- Scoring last week from mission `status` instead of merged PRs — delivered work sometimes reports `failed`.
+- Goals without binary done-conditions, or a focus block without an expiry date.
+- Filing `ready-to-work` issues missing the agent-ready contract (done-condition, context, out-of-scope, type label).
 - Decomposing an epic into slices too big to test+ship in one hourly cycle.
-- Pushing questions to Telegram/email — this skill is in-session; ask the person in front of you.
-- Flipping the cron or rewriting goals without showing the diff and getting a yes.
+- Open-ended question dribble — batch once, recommend first, park `[NEEDS CLARIFICATION]` topics.
+- Requiring a static `GH_TOKEN` — auth comes from App installation tokens (sessions) or the runner's own `gh` identity (local).
+- One mega-session across teams, or touching another team's config from this one.
+- Flipping the cron, setting budgets, or rewriting goals without showing the diff and getting a yes.
 
 ## Verification
+- The session opened with the four plan-vs-actual numbers, trend-arrowed.
 - Every promoted item carries the three signals and a one-line justification.
-- Every epic slice is independently deliverable, staging-testable, and deployable in ~one hourly cycle.
-- Goals reflect the reconciled decision; the "This week's focus" names ready first targets.
-- The auto-pylot cron state matches what the owner approved (verified via `GET /crew`).
+- Every `ready-to-work` issue satisfies the agent-ready contract; the weekly queue skews toward verifiable task types.
+- Goals carry done-conditions, guardrails (playbook hazards included), and a dated, expiring focus block; a `weekly-plan-update` ledger entry exists.
+- Budget and cron state match what the owner approved (verified via `GET /crew`).
 - The in-flight set from Step 1 appears nowhere in the hourly-ready queue.
+- Total owner attention spent: ≤30 minutes, ≤10 decisions, one batch.

--- a/skills/ops/weekly-plan/SKILL.md
+++ b/skills/ops/weekly-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly-plan
-description: Weekly roadmap deep-dive for a Pylot team. Deep-triages the full backlog (closes ghosts, re-scopes partials with cited evidence), re-ranks by OWNER LEVERAGE, surfaces open-questions as one batched decision digest, and proposes goal edits. Shapes the queue and the goals that the hourly auto-pylot then executes — it is the thinking counterpart to the hourly's execution.
+description: Interactive weekly roadmap session for a Pylot team (run in a Claude Code or pylot chat session — NOT headless). Pulls goals + backlog, ranks candidates by metrics + momentum + leverage, asks the owner for their perceived priorities and reconciles, deep-triages to kill ghosts, decomposes epics into hourly-sized testable+deployable slices, writes the reconciled goals, and activates/tunes the hourly auto-pylot. It is the thinking session that shapes what the hourly then executes.
 argument-hint: "org/repo [team]"
 user-invocable: true
 allowed-tools: Read, Write, Bash, Glob, Grep
@@ -8,183 +8,108 @@ allowed-tools: Read, Write, Bash, Glob, Grep
 
 # weekly-plan
 
-The hourly `auto-pylot` is a tight executor: it triages cheaply and dispatches the top 1–3 issues by impact. It cannot afford a deep roadmap dive every hour. `weekly-plan` is the slow, deliberate counterpart that runs once a week: it reads the *whole* backlog and the code behind it, kills stale work, re-ranks the roadmap by what actually unblocks the owner, batches every open question into one decision digest, and proposes goal edits. The hourly then executes the shaped backlog.
+The hourly `auto-pylot` is a tight executor: it triages cheaply and dispatches the top 1–3 issues. It can't afford a deep roadmap dive every hour, and it has no human to ask. `weekly-plan` is the **interactive** counterpart you run **with a person in the loop** — in a Claude Code session or a pylot chat session — to set direction for the week. It shapes the backlog and the goals; the hourly executes them.
 
-**Division of labor:** weekly-plan *shapes* (close, re-scope, re-rank, ask, propose goals). The hourly *executes* (dispatch). weekly-plan does **not** mass-dispatch missions — at most it dispatches the single top item if the queue is empty. One clean kill beats five grazing shots.
+**This is not a cron.** It asks the owner questions and waits for answers, so it only runs where a human can respond. There is **no Telegram, no push** — every question and the final digest are presented **in-session**.
+
+**Division of labor:** weekly-plan *shapes* (rank, ask, reconcile, triage, decompose, write goals, activate the hourly). The hourly *executes* (dispatch). One clean kill beats five grazing shots.
 
 ## When to Use
-
-- A weekly cron fires it (operator `infra.cto`, `task: /weekly-plan fellowship-dev/pylot infra`).
-- The owner runs `/weekly-plan` to think through roadmap priorities before a sprint.
-- The backlog feels stale, mislabeled, or full of half-done work and needs a reset.
+- The owner opens a CC or pylot-chat session to plan the week / set direction before turning the hourly loose.
+- The backlog feels stale, mislabeled, or unfocused and the goals need a reset.
+- After a big merge wave, to re-aim the hourly.
 
 ## Invocation
-
 ```
-/weekly-plan org/repo [team]
-```
-
-**Examples:**
-```
-/weekly-plan fellowship-dev/pylot infra
-/weekly-plan fellowship-dev/pylot            # team defaults to infra
+/weekly-plan org/repo [team]      # e.g. /weekly-plan fellowship-dev/pylot infra  (team defaults to infra)
 ```
 
-## Token & Environment
-
-In an operator container these are already in the environment (provided at boot). For a local run, source the ops env first.
-
+## Environment
+In a session these are already set (operator/chat boot); for a local run, source the ops env.
 ```bash
-export REPO="${1:?usage: /weekly-plan org/repo [team]}"
-export TEAM="${2:-infra}"
-# Local runs only — in the operator these are already set:
-# set -a; source "$HOME/Projects/fellowship-dev/claude-buddy/.env"; set +a
-: "${GH_TOKEN:?missing}"; : "${PYLOT_DISPATCH_TOKEN:?missing}"; : "${PYLOT_API_URL:?missing}"
-GH(){ gh "$@"; }
+export REPO="${1:?usage: /weekly-plan org/repo [team]}"; export TEAM="${2:-infra}"
+: "${GH_TOKEN:?}"; : "${PYLOT_DISPATCH_TOKEN:?}"; : "${PYLOT_API_URL:?}"
 GW(){ curl -sS -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" "$@"; }
 ```
 
 ---
 
 ## PRIME DIRECTIVE — research before you promote
+Before you rank, promote, or decompose ANY issue, research it **and its linked/sibling issues**: read the code, git history, linked PRs, and the thread. Most of a long-lived backlog is stale, partially done, or superseded. **Don't chase ghosts.** The default triage outcome is CLOSE or RE-SCOPE with cited evidence — promotion to the hourly's queue is *earned*.
 
-Before you close, re-scope, rank, or propose dispatching ANY issue, research it **and its
-linked/sibling issues**: read the code, the git history, the linked PRs, and the issue thread.
-Most of a long-lived backlog is stale, partially done, or superseded. **Do not chase ghosts.**
-The default outcome of triage is to CLOSE or RE-SCOPE with cited evidence — promotion to the
-dispatch queue is *earned* only when the work is real, unstarted, and goal-aligned. This is the
-same directive the team GOALS carry; weekly-plan applies it at roadmap scale.
+## Step 1 — Orient (load the ground truth)
+Never plan from titles. Load, for `$TEAM`:
+```bash
+GW "$PYLOT_API_URL/admin/goals/$TEAM"                 # current goals you're validating against
+GW "$PYLOT_API_URL/missions?status=running"           # in-flight — never re-rank these as unstarted
+GW "$PYLOT_API_URL/crew" | jq '.crews[]|select(.name=="'"$TEAM"'")|{cron,repos}'  # hourly state + scope
+```
+Read `docs/principles.md` if present — goals serve the invariants.
+
+## Step 2 — Compute the signals (metrics + momentum + leverage)
+Pull real numbers; don't hand-wave "leverage".
+```bash
+SINCE=$(date -u -v-10d +%Y-%m-%d 2>/dev/null || date -u -d '10 days ago' +%Y-%m-%d)
+# VELOCITY: how fast is the team closing? (throughput is often NOT the constraint — direction is)
+gh issue list --repo "$REPO" --state closed  --limit 200 --json closedAt  --jq "[.[]|select(.closedAt>\"$SINCE\")]|length"
+# MOMENTUM: what's actively moving right now?
+gh issue list --repo "$REPO" --state open --limit 300 --json number,title,updatedAt,labels \
+  --jq "sort_by(.updatedAt)|reverse|.[:25]|.[]|\"\(.number) \(.updatedAt[0:10]) [\(.labels|map(.name)|join(\",\"))] \(.title)\""
+# METRICS: age, priority label, ready-to-work vs blocked/open-questions, install/usage where it applies.
+```
+For each candidate score three axes: **leverage** (does it unblock the owner / a daily-use surface?), **momentum** (recently active, already in-flight?), **metrics** (ready vs blocked, age, impact ÷ effort). Flag **mislabeled priority** — a daily-use blocker sitting at P2 is a P0 in disguise.
+
+## Step 3 — Propose a ranking (in-session)
+Present, in the session, a short ranked shortlist with the three signals cited per item, plus: what's **ready** vs **needs re-triage**, and what's already **in-flight**. This is a proposal, not a verdict — it sets up Step 4.
+
+## Step 4 — Ask the owner for their perceived priorities
+Interactively reconcile your data-ranking with the owner's gut. In Claude Code use `AskUserQuestion`; in pylot chat, ask directly and wait. Surface where the data disagrees with the owner's read ("you ranked chat #1, but it's not dispatch-ready — devbox is the cleaner first fuel"). **The owner's call wins**; record the why.
+
+## Step 5 — Deep-triage the shortlist (anti-ghost)
+For each promoted candidate, do the research the PRIME DIRECTIVE demands (shallow-clone, read code + history + linked issues). Close done/dup and re-scope partials with a cited comment on the issue. Never close P0/P1.
+
+## Step 6 — Decompose epics into HOURLY-sized slices
+A big epic isn't dispatchable. Break each promoted epic into the smallest slices where every slice is:
+1. **independently deliverable** (one PR, no cross-slice barrier),
+2. **testable in staging** on its own, and
+3. **deployable** through develop→staging→prod within roughly **one hourly auto-pylot cycle**.
+File/relabel these `ready-to-work` so the hourly can pick one up, test it, and ship it each hour. Note what was sliced and what's deferred.
+
+## Step 7 — Write the reconciled goals
+Update `/goals` to match the decision, including a dated **"This week's focus"** block pointing the hourly at the ready, highest-ROI first targets. Show the diff; apply on confirmation.
+```bash
+# after confirmation:
+GW -X PUT "$PYLOT_API_URL/admin/goals/$TEAM" -H "Content-Type: text/plain" --data-binary @goals.new.md
+```
+
+## Step 8 — Activate / tune the hourly
+Bring the auto-pylot cron in line with the plan and, **with the owner's go**, enable it.
+```bash
+# enable (or adjust schedule) — send the FULL cron array back with auto-pylot enabled:true
+GW -X PATCH "$PYLOT_API_URL/admin/crew/$TEAM" -H "Content-Type: application/json" -d "$(jq -c ...)"
+GW "$PYLOT_API_URL/crew" | jq '.crews[]|select(.name=="'"$TEAM"'").cron'   # verify
+```
+
+## Step 9 — Session summary (in-session, no push)
+Present in the session: the ranking + the three signals, what was triaged (closed/re-scoped, with refs), the **hourly-ready queue** (top first), the epic slices created, the decisions captured, the goals diff, and the final auto-pylot state (enabled? schedule? first focus?).
 
 ---
 
-## Step 1: Orient
-
-Load the ground truth you will plan against. Never plan from issue titles alone.
-
-```bash
-# Current goals (the leverage order you are validating against)
-GW "$PYLOT_API_URL/admin/goals/$TEAM" | tee /tmp/wp-goals.md
-# Work already in flight — never re-dispatch or re-rank these as if unstarted
-GH issue list --repo "$REPO" --state open --label in-progress --label dispatched \
-   --json number,title,labels --jq '.[] | "\(.number)\t\(.title)"'
-```
-
-Also read `docs/principles.md` in the target repo if present — goals must serve the invariants.
-
-## Step 2: Pull the full backlog
-
-```bash
-GH issue list --repo "$REPO" --state open --limit 500 \
-  --json number,title,labels,createdAt,updatedAt,comments \
-  --jq 'sort_by(.updatedAt) | reverse | .[]
-        | "\(.number)\t\(.updatedAt[0:10])\t[\(.labels|map(.name)|join(","))]\t\(.title)"'
-```
-
-Group into themes (cluster by label + title): the owner-facing surfaces (chat, devbox, UI),
-platform health (reliability, secrets, migrations), epics, and pure polish.
-
-## Step 3: Deep-triage (anti-ghost) — close or re-scope with evidence
-
-For each candidate, do the research the PRIME DIRECTIVE demands. Shallow-clone the repo once and
-read the actual code + history rather than guessing from the thread.
-
-```bash
-git clone --depth 50 "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" /tmp/wp-src 2>/dev/null
-cd /tmp/wp-src   # use absolute paths; never cd before dispatching workers
-git log --oneline -30 -- <paths the issue touches>
-GH issue view <n> --repo "$REPO" --json body,comments  # read the thread + linked refs
-```
-
-Decide, with a one-line cited reason on the issue:
-
-| Finding | Action |
-|---|---|
-| Already implemented / merged | **Close** — cite the commit/PR. Never close P0/P1 (leave for human); `premature-close-checker` is the backstop. |
-| Superseded by a newer issue/PR | **Close as duplicate** — link the survivor. |
-| Partially done / scope crept | **Re-scope** — edit the body to the remaining vertical slice; relabel. |
-| Mislabeled priority | **Re-triage** — fix the `P*` label (see Step 4). |
-| Real, unstarted, goal-aligned | **Keep** — promote to the ranked queue (Step 4). |
-
-## Step 4: Re-rank by OWNER LEVERAGE
-
-This is the heart of the skill. Rank not by raw priority label but by **what unblocks the owner**.
-
-1. **Daily-use surfaces the owner cannot use come first.** A bug that blocks the owner from using
-   chat or a devbox outranks any backend nicety — even if it is labeled P2. Hunt for this
-   mislabeling explicitly: a `chat-ux`/`devbox` "can't use it" bug tagged P2 is a P0 in disguise.
-   Fix the label and cite why.
-2. **Then platform-health by impact ÷ effort** (reliability, observability, secrets, migrations).
-3. **Decompose epics into vertical slices.** A big epic (multi-tenant, GitHub-App) is not
-   dispatchable as one mission — break out the smallest independently-deliverable slice and rank
-   *that*. (Mirror the `to-issues` / `issue-to-prd` skills.)
-4. Produce a ranked **dispatch-ready queue** (issues that survived Step 3 and are fully specified).
-
-## Step 5: Surface open-questions as ONE decision digest
-
-For every `open-questions` (or otherwise under-specified) issue, do the research, then post a
-recommendation comment on the issue so the thread carries your reasoning:
-
-```bash
-GH issue comment <n> --repo "$REPO" --body "weekly-plan: recommend <option> because <evidence>. Open decision: <the question for the owner>."
-```
-
-Then compile **a single batched digest** of every decision the owner must make this week — do not
-ping per-issue. Never dispatch an under-specified issue blind: prep it (recommendation + the one
-question), then ask. Send the digest to the owner via Telegram (the executor resolves
-`TELEGRAM_CHAT_ID`/`TELEGRAM_BOT_TOKEN`):
-
-```bash
-GW -X POST "$PYLOT_API_URL/admin/notify" -H "Content-Type: application/json" \
-   -d "$(jq -nc --arg t "$DIGEST" '{text:$t}')" || echo "(notify endpoint optional; digest also in the report)"
-```
-
-## Step 6: Propose goal edits — never silently overwrite
-
-Diff the current goals against the re-ranked reality. If the leverage order has shifted (e.g. a
-surface the owner now needs has risen, or a finished goal should retire), draft the new GOALS.md
-and present the diff for approval. Apply only on explicit owner approval or when invoked with an
-`--apply` argument — autonomous goal rewrites are how an operator starts chasing the wrong work.
-
-```bash
-# Draft only — write the proposal, show the diff, DO NOT PUT without approval:
-diff <(cat /tmp/wp-goals.md) /tmp/wp-goals.proposed.md || true
-# On approval:
-# GW -X PUT "$PYLOT_API_URL/admin/goals/$TEAM" -H "Content-Type: text/plain" --data-binary @/tmp/wp-goals.proposed.md
-```
-
-## Step 7: Produce the weekly plan report
-
-Write a mission report (and post the digest to the owner). Sections:
-
-1. **Leverage summary** — the top 3 themes this week, in owner-leverage order, one line each.
-2. **Triaged** — counts: closed-as-done, closed-as-dup, re-scoped, re-triaged (with issue refs).
-3. **Dispatch-ready queue** — the ranked, fully-specified issues the hourly should execute, top first.
-4. **Decisions needed** — the batched open-questions digest (issue ref + recommendation + the question).
-5. **Proposed goal changes** — the GOALS diff, or "no change".
-
----
-
-## Boundaries — hand off to the hourly
-
-- **Do NOT mass-dispatch.** Respect max-3-concurrent and the in-flight set from Step 1. At most,
-  dispatch the single top queue item if nothing is running and it is fully specified.
-- **Do NOT close P0/P1** — surface them for a human.
-- **Do NOT rewrite goals** without owner approval / `--apply`.
-- The deliverable is a *shaped backlog + a decision digest + a goals proposal*, not a pile of branches.
+## Boundaries
+- **Interactive only** — needs a human to answer; never run headless/cron.
+- **Shapes, doesn't mass-dispatch** — respects max-3-concurrent; at most dispatches the single top ready item.
+- **Never** closes P0/P1, rewrites goals, or flips the cron without explicit owner confirmation.
 
 ## Anti-patterns
-
-- Ranking by the `P*` label instead of by owner leverage — the whole point is to catch mislabeling.
-- Triaging from issue titles without reading code/history — that is exactly the ghost-chasing the
-  PRIME DIRECTIVE forbids.
-- Per-issue owner pings — batch every decision into one digest; the owner's time is sacred.
-- Dispatching an under-specified issue "to make progress" — prep it and ask instead.
-- Auto-applying goal edits — propose, show the diff, wait.
+- Ranking by the `P*` label instead of the three signals — the point is to catch mislabeling.
+- Hand-waving "leverage" without pulling velocity/momentum numbers.
+- Decomposing an epic into slices too big to test+ship in one hourly cycle.
+- Pushing questions to Telegram/email — this skill is in-session; ask the person in front of you.
+- Flipping the cron or rewriting goals without showing the diff and getting a yes.
 
 ## Verification
-
-- Every closed issue has a comment citing the commit/PR/duplicate that justifies it.
-- Every item in the dispatch-ready queue is fully specified (a worker could start with no questions).
-- The decision digest contains every `open-questions` issue, each with a recommendation.
-- If goals changed, the report shows the diff and an approval reference; otherwise it says "no change".
-- The in-flight set from Step 1 appears nowhere in the dispatch-ready queue.
+- Every promoted item carries the three signals and a one-line justification.
+- Every epic slice is independently deliverable, staging-testable, and deployable in ~one hourly cycle.
+- Goals reflect the reconciled decision; the "This week's focus" names ready first targets.
+- The auto-pylot cron state matches what the owner approved (verified via `GET /crew`).
+- The in-flight set from Step 1 appears nowhere in the hourly-ready queue.

--- a/skills/ops/weekly-plan/SKILL.md
+++ b/skills/ops/weekly-plan/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: weekly-plan
+description: Weekly roadmap deep-dive for a Pylot team. Deep-triages the full backlog (closes ghosts, re-scopes partials with cited evidence), re-ranks by OWNER LEVERAGE, surfaces open-questions as one batched decision digest, and proposes goal edits. Shapes the queue and the goals that the hourly auto-pylot then executes — it is the thinking counterpart to the hourly's execution.
+argument-hint: "org/repo [team]"
+user-invocable: true
+allowed-tools: Read, Write, Bash, Glob, Grep
+---
+
+# weekly-plan
+
+The hourly `auto-pylot` is a tight executor: it triages cheaply and dispatches the top 1–3 issues by impact. It cannot afford a deep roadmap dive every hour. `weekly-plan` is the slow, deliberate counterpart that runs once a week: it reads the *whole* backlog and the code behind it, kills stale work, re-ranks the roadmap by what actually unblocks the owner, batches every open question into one decision digest, and proposes goal edits. The hourly then executes the shaped backlog.
+
+**Division of labor:** weekly-plan *shapes* (close, re-scope, re-rank, ask, propose goals). The hourly *executes* (dispatch). weekly-plan does **not** mass-dispatch missions — at most it dispatches the single top item if the queue is empty. One clean kill beats five grazing shots.
+
+## When to Use
+
+- A weekly cron fires it (operator `infra.cto`, `task: /weekly-plan fellowship-dev/pylot infra`).
+- The owner runs `/weekly-plan` to think through roadmap priorities before a sprint.
+- The backlog feels stale, mislabeled, or full of half-done work and needs a reset.
+
+## Invocation
+
+```
+/weekly-plan org/repo [team]
+```
+
+**Examples:**
+```
+/weekly-plan fellowship-dev/pylot infra
+/weekly-plan fellowship-dev/pylot            # team defaults to infra
+```
+
+## Token & Environment
+
+In an operator container these are already in the environment (provided at boot). For a local run, source the ops env first.
+
+```bash
+export REPO="${1:?usage: /weekly-plan org/repo [team]}"
+export TEAM="${2:-infra}"
+# Local runs only — in the operator these are already set:
+# set -a; source "$HOME/Projects/fellowship-dev/claude-buddy/.env"; set +a
+: "${GH_TOKEN:?missing}"; : "${PYLOT_DISPATCH_TOKEN:?missing}"; : "${PYLOT_API_URL:?missing}"
+GH(){ gh "$@"; }
+GW(){ curl -sS -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" "$@"; }
+```
+
+---
+
+## PRIME DIRECTIVE — research before you promote
+
+Before you close, re-scope, rank, or propose dispatching ANY issue, research it **and its
+linked/sibling issues**: read the code, the git history, the linked PRs, and the issue thread.
+Most of a long-lived backlog is stale, partially done, or superseded. **Do not chase ghosts.**
+The default outcome of triage is to CLOSE or RE-SCOPE with cited evidence — promotion to the
+dispatch queue is *earned* only when the work is real, unstarted, and goal-aligned. This is the
+same directive the team GOALS carry; weekly-plan applies it at roadmap scale.
+
+---
+
+## Step 1: Orient
+
+Load the ground truth you will plan against. Never plan from issue titles alone.
+
+```bash
+# Current goals (the leverage order you are validating against)
+GW "$PYLOT_API_URL/admin/goals/$TEAM" | tee /tmp/wp-goals.md
+# Work already in flight — never re-dispatch or re-rank these as if unstarted
+GH issue list --repo "$REPO" --state open --label in-progress --label dispatched \
+   --json number,title,labels --jq '.[] | "\(.number)\t\(.title)"'
+```
+
+Also read `docs/principles.md` in the target repo if present — goals must serve the invariants.
+
+## Step 2: Pull the full backlog
+
+```bash
+GH issue list --repo "$REPO" --state open --limit 500 \
+  --json number,title,labels,createdAt,updatedAt,comments \
+  --jq 'sort_by(.updatedAt) | reverse | .[]
+        | "\(.number)\t\(.updatedAt[0:10])\t[\(.labels|map(.name)|join(","))]\t\(.title)"'
+```
+
+Group into themes (cluster by label + title): the owner-facing surfaces (chat, devbox, UI),
+platform health (reliability, secrets, migrations), epics, and pure polish.
+
+## Step 3: Deep-triage (anti-ghost) — close or re-scope with evidence
+
+For each candidate, do the research the PRIME DIRECTIVE demands. Shallow-clone the repo once and
+read the actual code + history rather than guessing from the thread.
+
+```bash
+git clone --depth 50 "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" /tmp/wp-src 2>/dev/null
+cd /tmp/wp-src   # use absolute paths; never cd before dispatching workers
+git log --oneline -30 -- <paths the issue touches>
+GH issue view <n> --repo "$REPO" --json body,comments  # read the thread + linked refs
+```
+
+Decide, with a one-line cited reason on the issue:
+
+| Finding | Action |
+|---|---|
+| Already implemented / merged | **Close** — cite the commit/PR. Never close P0/P1 (leave for human); `premature-close-checker` is the backstop. |
+| Superseded by a newer issue/PR | **Close as duplicate** — link the survivor. |
+| Partially done / scope crept | **Re-scope** — edit the body to the remaining vertical slice; relabel. |
+| Mislabeled priority | **Re-triage** — fix the `P*` label (see Step 4). |
+| Real, unstarted, goal-aligned | **Keep** — promote to the ranked queue (Step 4). |
+
+## Step 4: Re-rank by OWNER LEVERAGE
+
+This is the heart of the skill. Rank not by raw priority label but by **what unblocks the owner**.
+
+1. **Daily-use surfaces the owner cannot use come first.** A bug that blocks the owner from using
+   chat or a devbox outranks any backend nicety — even if it is labeled P2. Hunt for this
+   mislabeling explicitly: a `chat-ux`/`devbox` "can't use it" bug tagged P2 is a P0 in disguise.
+   Fix the label and cite why.
+2. **Then platform-health by impact ÷ effort** (reliability, observability, secrets, migrations).
+3. **Decompose epics into vertical slices.** A big epic (multi-tenant, GitHub-App) is not
+   dispatchable as one mission — break out the smallest independently-deliverable slice and rank
+   *that*. (Mirror the `to-issues` / `issue-to-prd` skills.)
+4. Produce a ranked **dispatch-ready queue** (issues that survived Step 3 and are fully specified).
+
+## Step 5: Surface open-questions as ONE decision digest
+
+For every `open-questions` (or otherwise under-specified) issue, do the research, then post a
+recommendation comment on the issue so the thread carries your reasoning:
+
+```bash
+GH issue comment <n> --repo "$REPO" --body "weekly-plan: recommend <option> because <evidence>. Open decision: <the question for the owner>."
+```
+
+Then compile **a single batched digest** of every decision the owner must make this week — do not
+ping per-issue. Never dispatch an under-specified issue blind: prep it (recommendation + the one
+question), then ask. Send the digest to the owner via Telegram (the executor resolves
+`TELEGRAM_CHAT_ID`/`TELEGRAM_BOT_TOKEN`):
+
+```bash
+GW -X POST "$PYLOT_API_URL/admin/notify" -H "Content-Type: application/json" \
+   -d "$(jq -nc --arg t "$DIGEST" '{text:$t}')" || echo "(notify endpoint optional; digest also in the report)"
+```
+
+## Step 6: Propose goal edits — never silently overwrite
+
+Diff the current goals against the re-ranked reality. If the leverage order has shifted (e.g. a
+surface the owner now needs has risen, or a finished goal should retire), draft the new GOALS.md
+and present the diff for approval. Apply only on explicit owner approval or when invoked with an
+`--apply` argument — autonomous goal rewrites are how an operator starts chasing the wrong work.
+
+```bash
+# Draft only — write the proposal, show the diff, DO NOT PUT without approval:
+diff <(cat /tmp/wp-goals.md) /tmp/wp-goals.proposed.md || true
+# On approval:
+# GW -X PUT "$PYLOT_API_URL/admin/goals/$TEAM" -H "Content-Type: text/plain" --data-binary @/tmp/wp-goals.proposed.md
+```
+
+## Step 7: Produce the weekly plan report
+
+Write a mission report (and post the digest to the owner). Sections:
+
+1. **Leverage summary** — the top 3 themes this week, in owner-leverage order, one line each.
+2. **Triaged** — counts: closed-as-done, closed-as-dup, re-scoped, re-triaged (with issue refs).
+3. **Dispatch-ready queue** — the ranked, fully-specified issues the hourly should execute, top first.
+4. **Decisions needed** — the batched open-questions digest (issue ref + recommendation + the question).
+5. **Proposed goal changes** — the GOALS diff, or "no change".
+
+---
+
+## Boundaries — hand off to the hourly
+
+- **Do NOT mass-dispatch.** Respect max-3-concurrent and the in-flight set from Step 1. At most,
+  dispatch the single top queue item if nothing is running and it is fully specified.
+- **Do NOT close P0/P1** — surface them for a human.
+- **Do NOT rewrite goals** without owner approval / `--apply`.
+- The deliverable is a *shaped backlog + a decision digest + a goals proposal*, not a pile of branches.
+
+## Anti-patterns
+
+- Ranking by the `P*` label instead of by owner leverage — the whole point is to catch mislabeling.
+- Triaging from issue titles without reading code/history — that is exactly the ghost-chasing the
+  PRIME DIRECTIVE forbids.
+- Per-issue owner pings — batch every decision into one digest; the owner's time is sacred.
+- Dispatching an under-specified issue "to make progress" — prep it and ask instead.
+- Auto-applying goal edits — propose, show the diff, wait.
+
+## Verification
+
+- Every closed issue has a comment citing the commit/PR/duplicate that justifies it.
+- Every item in the dispatch-ready queue is fully specified (a worker could start with no questions).
+- The decision digest contains every `open-questions` issue, each with a recommendation.
+- If goals changed, the report shows the diff and an approval reference; otherwise it says "no change".
+- The in-flight set from Step 1 appears nowhere in the dispatch-ready queue.


### PR DESCRIPTION
## /weekly-plan — the interactive thinking session that aims the hourly auto-pylot

**One team per session, run sequentially** (`/weekly-plan team [org/repo]`). Interactive only — Claude Code or pylot chat; never headless, never cron, no push channels. weekly-plan *shapes* (score, rank, ask, triage, decompose, write goals, set budget, tune the hourly); the hourly auto-pylot *executes*.

### Session flow
0. **Plan-vs-actual scorecard** — 4 numbers vs last week (planned-vs-merged, rework rate, cost/merged-PR, top failure cause), scored from GitHub, not mission status. Portfolio cost view (read-only, all teams) for budget context.
1. **Orient** — goals, running missions, crew config, **per-repo playbooks** (guardrails flow into goals).
2. **Signals** — velocity/momentum/metrics per repo; flag mislabeled priorities; weight queue toward verifiable task types (chores/fixes/tests merge autonomously at far higher rates than features/perf).
3. **Propose** — ranked shortlist + budget proposal (concentrate on what's converting).
4. **One batched questionnaire** — ≤10 decisions, recommendation-first, owner taps numbers or bulk-accepts; >2-exchange topics parked as `[NEEDS CLARIFICATION]`. Owner's call wins. Target ≤30 min of owner attention.
5. **Anti-ghost deep-triage** — default outcome is CLOSE/RE-SCOPE with cited evidence; never closes P0/P1.
6. **Agent-ready epic slices** — every `ready-to-work` issue carries: binary machine-checkable done-condition, context links, out-of-scope line, task-type label.
7. **Goals write** — north star + guardrails + done-conditions + dated **"This week's focus (expires YYYY-MM-DD)"** (expired plan = void → hourly falls back to safe maintenance). Diff shown, applied on confirmation, ledger provenance entry.
8. **Budget + cron** — `budget_daily_usd` as a planning object; cron via full-array read-modify-write. Both confirmed first.
9. **In-session summary** + optional dispatch of the single top ready item (explicit `/skill` task format).

### Auth model
No static `GH_TOKEN`. Operator/chat sessions use the platform's GitHub App installation tokens (`git-credential-pylot`); local CC sessions use the runner's own `gh` identity. Generic for any pylot org/team — nothing org-specific in the skill.

### Verified against the gateway
`GET /missions` (status/agent/repo/org/limit — no team/date params), `GET /costs/summary?days=N`, `PUT /admin/goals/:team` (text/plain), `POST /admin/crew/:team/ledger`, `PATCH /admin/crew/:team` (cron replaces whole array).

Design discussion, research, and review: see comment thread below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
