### PR TITLE
docs(release-train-runner): Lexgo default branch is now develop

### DIFF
--- a/skills/ops/release-train-runner/shared/test-commands.md
+++ b/skills/ops/release-train-runner/shared/test-commands.md
@@ -19,7 +19,7 @@ CLAUDE.md first.
 
 ## Default branch reminder
 
-Lexgo uses `master`, most others use `main`. Never assume:
+Lexgo's rails-backend uses `develop` (gitflow — `master` deploys production on push, never target it), most others use `main`. Never assume:
 
 ```bash
 DEFAULT_BRANCH=$(gh repo view $REPO --json defaultBranchRef -q .defaultBranchRef.name)

--- a/skills/ops/release-train-runner/stages/01-preflight/CONTEXT.md
+++ b/skills/ops/release-train-runner/stages/01-preflight/CONTEXT.md
@@ -10,8 +10,9 @@ state on the default branch — ready for the release branch to be cut.
 
 ## Steps
 
-1. Confirm the default branch (already in stage 00 handoff; re-verify if unset). Lexgo uses
-   `master`, most others use `main` — never assume:
+1. Confirm the default branch (already in stage 00 handoff; re-verify if unset). Lexgo's
+   rails-backend uses `develop` (gitflow: `develop`→staging, `master`→prod — never target
+   `master`, pushing it deploys production), most others use `main` — never assume:
 ```bash
 DEFAULT_BRANCH=$(gh repo view $REPO --json defaultBranchRef -q .defaultBranchRef.name)
 ```


### PR DESCRIPTION
rails-backend moved to gitflow (~2026-05-28): `develop` is the default branch and deploys **staging** on push; `master` deploys **production** on push.

Two release-train-runner docs still said "Lexgo uses `master`" — under the new model that's exactly the branch agents must never target. Updated both reminders to describe the gitflow and the prod-deploy hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)