### PR TITLE
feat(ops): add refactor-codebase skill (dogfooded over 5 prod iterations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Skills for CI, deployment, operations, and evidence workflows.
 | [`ops/daily-report`](skills/ops/daily-report/) | Standard format for daily/rollcall team reports |
 | [`ops/write-report`](skills/ops/write-report/) | Write a mission report to reports/ — resolves paths, generates timestamps, posts to Quest |
 | [`ops/weekly-plan`](skills/ops/weekly-plan/) | Interactive weekly planning session for ONE team (CC / pylot chat) — plan-vs-actual scorecard, full linked briefing (last week, in-flight, half-done epics, colleagues' work), then a spec-plan-style interview (one question per turn, recommendation-first), anti-ghost triage, agent-ready epic slices, goals with done-conditions + expiring focus block, budget + hourly auto-pylot tuning. Run once per team, sequentially |
+| [`ops/refactor-codebase`](skills/ops/refactor-codebase/) | Autonomously refactor a codebase across many behavior-preserving cycles — decompose fat files by domain, deepen shallow modules, pay down architectural debt — driven by a persistent masterplan and verification gates. Complements `improve-codebase-architecture` (which only finds and reports opportunities) by actually doing the refactor, safely, over many sessions |
 
 ## Namespace Convention
 

--- a/skills/ops/refactor-codebase/CATALOG.md
+++ b/skills/ops/refactor-codebase/CATALOG.md
@@ -1,0 +1,67 @@
+# The Refactoring Catalog & Risk Ladder
+
+This file is the **menu of moves**, ranked by how safely an autonomous agent can perform them. [SELECTION.md](SELECTION.md) tells you *what* to target and *which direction*; this file tells you *which named refactoring* to apply and *what to expect* when you do.
+
+> **Governing principle: approachability == determinism.** A refactoring is safe to the exact degree that a deterministic tool (compiler, type-checker, LSP, codemod) can perform and verify it. Text generation is unreliable for structural transforms. So an autonomous loop should spend **most cycles in tiers T1–T3**, gate **T4** on "all callers in-repo + green oracle," and treat **T5** as characterization-test-first, tiny-step, reviewed work — never a one-shot generative rewrite.
+
+## The risk / approachability ladder
+
+| Tier | Refactorings | Why here | Tooling | Blast radius | Provability |
+|---|---|---|---|---|---|
+| **T1 — Safest** | Rename, Extract/Inline Variable, Extract/Inline Function (local), Remove Dead Code, Replace Magic Literal | mechanically behavior-preserving; LSP computes a workspace-wide edit from the symbol graph | fully automated (LSP/IDE) | tiny–wide but **mechanical** | trivial; compiler/type-checker |
+| **T2 — Low** | Change Function Declaration (internal), Decompose/Consolidate Conditional, Guard Clauses, Split Variable, Replace Temp with Query, Introduce Parameter Object, Slide/Move Statements | local or single-signature; deterministic recipe, edits ripple to call sites | mostly automated | function → call sites | tests at the function boundary |
+| **T3 — Medium** | Move Method/Field, Extract Class, Inline Class, Hide Delegate, Encapsulate Field/Collection, Replace Conditional with Polymorphism, Pull Up/Push Down | cross-object; references, imports, visibility, `this`-binding must propagate | partial (IntelliJ strong, weaker elsewhere) | multi-file | needs integration tests |
+| **T4 — High** | Change a **public/exported** API or signature, Split Phase, Combine Functions into Class, Replace Error Code with Exception, Substitute Algorithm, Replace Primitive with Object across a domain | crosses module/package boundary; **callers you cannot see**; semantics can shift | codemods help, need review | whole module + downstream | hard — callers may be out of repo |
+| **T5 — Riskiest** | **Split a god-file / decompose a fat module**, Replace Inheritance with Delegation (& inverse), Extract/Collapse Hierarchy, change architecture/layering | no single deterministic transform; design judgment; many hand-written delegations; easy to silently break | mostly manual | whole subsystem | very hard; only characterization/behavioral tests catch regressions |
+
+**Note the consequence for this skill's original instinct:** "decompose the big files" is **T5 — the hardest, riskiest tier.** Do not treat it as the default. Reach for it when SELECTION.md flags a genuine churning hotspot, OR when a file is simply too large for an agent to read whole (the agent-navigability objective — see [SELECTION.md](SELECTION.md)) — **and** in both cases only when the deep-module acceptance test will hold AND you have a trustworthy oracle. Even then it's *staged*: many small, independently-verified commits, never a one-shot rewrite. Often the higher-ROI, lower-risk win is a cluster of T1–T3 moves inside the hotspot first.
+
+## What a finding looks like, expected effort, expected diff
+
+| Tier | What the opportunity looks like | Typical effort | Typical diff |
+|---|---|---|---|
+| **T1** | cryptic name; an expression repeated 3×; a one-letter temp; an unreferenced symbol | seconds–minutes (one IDE action) | 1–30 lines; a rename may touch many files but is mechanical |
+| **T2** | a 60-line function doing 3 things; a nested `if/else` pyramid; a boolean flag arg; a long parameter list | minutes–~1 hr | 20–100 lines, localized |
+| **T3** | a method referencing another class's data more than its own (Feature Envy → Move); a class with two responsibilities (→ Extract Class); a `switch` on a type code (→ polymorphism) | 1–4 hrs incl. tests | 100–400 lines across a few files |
+| **T4** | a widely-imported function with a wrong signature; an error-code convention threaded through a layer; a raw primitive used as a domain concept everywhere | half-day–days; coordination | hundreds–thousands of lines (call-site fan-out) |
+| **T5** | a 2,000-line god file that is also a churning hotspot; an inheritance tree used only for code reuse; a layering violation | days–weeks, **staged** | very large — **must be split into many small, independently-reviewed commits** |
+
+## The catalog by category (Fowler)
+
+Use these names in cycle specs and commit messages so reviews are unambiguous. Full catalog: refactoring.com/catalog; taxonomy: refactoring.guru.
+
+- **Composing Methods** — Extract/Inline Function, Extract/Inline Variable, Replace Temp with Query, Split Variable, Replace Method with Method Object, Substitute Algorithm.
+- **Moving Features** — Move Method, Move Field, Extract Class, Inline Class, Hide Delegate, Remove Middle Man.
+- **Organizing Data** — Encapsulate Field/Collection, Replace Magic Number with Constant, Replace Primitive with Object, Replace Type Code with Subclasses/Strategy.
+- **Simplifying Conditionals** — Decompose/Consolidate Conditional, Replace Nested Conditional with Guard Clauses, Replace Conditional with Polymorphism, Introduce Special Case (Null Object).
+- **Simplifying Method Calls** — Change Function Declaration (rename/add/remove param), Introduce Parameter Object, Preserve Whole Object, Separate Query from Modifier, Replace Constructor with Factory.
+- **Dealing with Generalization** — Pull Up / Push Down Field/Method, Extract Super/Subclass/Interface, Collapse Hierarchy, **Replace Inheritance with Delegation** (T5 — no deterministic transform; choose what to delegate by hand).
+
+## Smell → refactoring map (diagnosis to move)
+
+| Smell | Refactoring | Tier |
+|---|---|---|
+| Long Method | Extract Function; Decompose Conditional; Replace Temp with Query | T1–T2 |
+| Large / God Class | Extract Class; Extract Subclass; Extract Interface | T3 (→T5 if it's the whole god-file) |
+| Feature Envy | Move Method; Extract+Move | T3 |
+| Data Class | Move behavior to the data; Encapsulate Field | T2–T3 |
+| Long Parameter List | Introduce Parameter Object; Preserve Whole Object | T2 |
+| Primitive Obsession | Replace Primitive with Object | T4 |
+| Switch on type code | Replace Conditional with Polymorphism | T3 |
+| Duplicated Code | Extract Function/Class; Pull Up Method | T1–T3 |
+| Shotgun Surgery | Move Method/Field; Inline Class (consolidate) | T3 |
+| Divergent Change | Extract Class (split by reason-to-change) | T3–T5 |
+
+## Tool support (automation correlates with safety)
+
+- **Deterministic, reliable:** Rename, Extract/Inline, Change signature, Move file/symbol — via LSP-backed IDEs. **IntelliJ/Rider** are the gold standard; **gopls** (Go), **rope** (Python), TS/JS language servers.
+- **Scripted at scale:** mechanical pattern migrations via **jscodeshift** / **ast-grep** / **comby** (AST-aware, far safer than regex). Robust for ultra-large codebases.
+- **Manual judgment required:** god-file split, architecture change, inheritance→delegation, algorithm substitution. These get characterization tests + small reviewed steps, not generation.
+
+**Rule:** prefer a semantic tool over hand text-edits whenever one exists for the language — it updates every call site/import/type atomically and kills the dropped-reference failure class. When none exists, move bodies **verbatim** and lean on the reverse-reference scan + the AST node-count tripwire ([GATES.md](GATES.md)).
+
+## Scale guidance
+
+- **Small (<10k LOC):** favor T1–T3 by hand/IDE in single PRs; prioritize readability smells (fast ROI, near-zero risk). Often the right move is *consolidating* shallow files, not splitting.
+- **Medium (10k–100k):** Extract Class / Move Method / module splits (T3) become the high-value plays. Public-API changes (T4) are now real — identify in-repo vs out-of-repo callers first. Codemods start paying off.
+- **Large (100k+/monorepo):** automate the repetitive low-value work with codemods; **split big changes into independently-tested chunks** (the Google "Rosie" model). Prerequisites (consistent formatters first) enable everything. Outside Google you won't have global test-against-all-users infra, so your leverage is: deterministic codemods + tiny verified diffs + a strong oracle.

--- a/skills/ops/refactor-codebase/CYCLE.md
+++ b/skills/ops/refactor-codebase/CYCLE.md
@@ -1,0 +1,55 @@
+# The Cycle Protocol
+
+One cycle = **one structural change, proven behavior-preserving, committed in isolation.** Keep cycles small enough that the diff is reviewable in one sitting and revertable in one command.
+
+## Steps
+
+> **Once per repo, before cycle 1:** run pre-flight ([PREREQUISITES.md](PREREQUISITES.md)). No trustworthy oracle → no refactor. Validate the oracle with mutation testing before relying on it.
+
+### a. Pick target + technique
+- From the masterplan worklist, take the **worst-first** item — ranked by **churn × complexity**, not size ([SELECTION.md](SELECTION.md)). Re-confirm it's still the worst with a quick `Explore` pass (terrain shifts between cycles).
+- Confirm the **direction** (split vs consolidate) from the smell, and pick the **risk tier** ([CATALOG.md](CATALOG.md)) — prefer T1–T3; a god-file split is T5 (characterization-first, staged).
+- Choose the technique by shape (see [TECHNIQUES.md](TECHNIQUES.md)):
+  - pure-export / helper module → **barrel-split**
+  - factory/handler module → **compose-behind-factory**
+  - one cohesive cluster inside a bigger file → **extract module**
+  - risky replacement of a live path → **strangler-fig**
+- Write a one-paragraph **cycle spec**: the target, the technique, the exact files, and — critically — the **done condition as a runnable check** (e.g. "bundle diff empty AND `tests/` exit 0 AND no files touched outside `src/<domain>/`").
+
+### b. Pin behavior (establish the oracle BEFORE editing)
+- Run the **project's real suite** (the one CI runs — include integration/e2e and DB-seeded tests where the environment allows, not just unit tests) on a clean tree; **record the baseline** (must be green, or a known-stable set — see note). If the documented command is stale or the suite won't run cleanly, first make it runnable and reconcile it against the actual test files — see [PREREQUISITES.md](PREREQUISITES.md#make-the-suite-actually-runnable). Derive green from the **parsed pass/fail tally**, not the runner's exit code, which can lie (open handles, force-exit, teardown warnings).
+- Capture the **API-surface / bundle snapshot** that the byte-identical gate will diff against (exported-symbol manifest, or a bundler output hash). See [GATES.md](GATES.md#byte-identical).
+- If coverage of the target is thin: write **characterization tests** that pin what the code *actually does today* (warts and all). Optionally **mutation-test** the existing tests first — surviving mutants show exactly where the oracle is blind; add characterization tests there before you trust it. See [GATES.md](GATES.md#oracle).
+
+> **Stable-red baselines.** If the suite already has failures, a "byte-identical before/after" comparison still works as a *delta* oracle — but it only proves you didn't make things *worse*, not that the code is correct. Prefer to green the suite first. If you can't, record the exact pre-existing failure set in the cycle spec and assert it is **unchanged**, never just "still fails."
+
+### c. Implement (clean baseline, fresh context)
+- Work from a **clean baseline with a one-command revert**. Pick isolation by environment (see SKILL.md → [Adapt to the environment](SKILL.md#environment)):
+  - **Ephemeral box (sandbox / devbox / CI container):** you own the machine — work **directly on a branch** and use everything it offers (services, DB seeds, integration suite). No worktree. Revert = reset / re-checkout.
+  - **Shared workstation:** use a worktree or dedicated clone so the loop can't disturb other in-progress work, and so parallel cycles don't collide.
+- Prefer a **fresh subagent** handed the cycle spec — it executes without the noise of the planning conversation.
+- Where the toolchain supports it, prefer **semantic tools** (LSP move/rename; codemods: ast-grep / jscodeshift / comby) over hand text-edits, especially on large files — they update every call site, import, and type atomically and kill the dropped-reference failure class. Otherwise move bodies **verbatim** and rely on the reverse-reference scan.
+
+### d. Gate ladder (cheap → expensive; revert on first red)
+Run in order so it fails fast. Full definitions in [GATES.md](GATES.md):
+1. typecheck / compile / lint
+2. **byte-identical API-surface or bundle diff** (the headline gate for pure re-org). For a *setup* cycle that introduces an abstraction/indirection before a later move (branch-by-abstraction / Mikado leaf), use the **surface-identical variant** instead: exported-symbol manifest empty-diff + moved bodies byte-identical + bundle/AST delta "small & explained," not `== 0` ([GATES.md](GATES.md#surface-identical))
+3. characterization / golden-master diff
+4. full existing test suite (exit 0; no silently-added skips)
+5. scope & idempotency (no edits outside declared paths; re-running the step is a no-op)
+6. **two-stage adversarial review** — a fresh-context grader sees only the diff + spec (grader ≠ worker): stage 1 spec-compliance, stage 2 code/deep-module quality
+7. deep-module quality check (did the interface actually narrow? exported-symbol count vs LOC)
+
+### e. Commit + record
+- **All green:** commit exactly one structural change with a message that states target + technique + evidence. Update the masterplan scoreboard.
+- **Any red:** revert to the last green checkpoint. Diagnose, shrink the cycle, retry. Do not patch forward on top of a red gate.
+
+## Cycle hygiene
+- One domain / one concern per commit — never batch unrelated moves.
+- Every commit is a clean rollback point and an independently-reviewable diff.
+- A failure in cycle N must never poison cycles 1..N-1.
+- If a cycle keeps failing the same gate, that's the masterplan telling you the split is wrong — revisit the plan, don't brute-force the code.
+- **Run the full mandatory gate set every cycle; never silently downgrade.** Later "trivial" cycles must still run the mandatory gates ([GATES.md](GATES.md#which-gates-run-every-cycle-no-silent-erosion)); any gate you scale down for a provably-safe move must be **recorded with a reason in the scoreboard**. An unrecorded downgrade is a gate violation.
+- **No process-narrating comments in the code.** The refactor's story (cycle numbers, "extracted from X", "re-exported here so importers stay unchanged") belongs in the commit message and the PR, **never** in source comments. A comment like `// Extracted to db/ledger.mjs (cycle 3/N). Re-exported so the public surface stays unchanged.` is noise that ages instantly and leaks the migration process into the code. Comments explain *what the code does and why*, not how it got here. **Enforce this with a grep gate, not willpower** — a prose-only rule gets violated under autonomy (especially when the file you're carving *already* contains inherited process comments and the worker mirrors the surrounding convention). Fail the cycle if the diff *adds* lines matching, case-insensitive, roughly: `extracted (to|from)|re-exported here|public surface (stays|unchanged)|cycle \d+\s*\/\s*N|importers stay unchanged`. Scope the grep to **added** lines in **new/edited** files so it never trips on inherited comments you were told to leave alone. The barrel/re-export is self-evident from the `export … from` line; if it genuinely needs a note, one terse line about the *design* (e.g. why state lives in a private holder), not the *process*. **Write NEW files clean — but don't scrub *inherited* process comments mid-cycle.** If earlier cycles (or another author) left older-convention process comments in files you're not otherwise touching, leave them: reformatting them is out-of-scope churn that bloats the diff and violates one-hat. Sweep them in a dedicated, separately-labeled cleanup cycle if they're worth removing.
+- **Update docs the change touches, in the same commit/PR.** If a cycle renames or relocates something the docs reference, or makes a documented command/setup step wrong, fix the doc as part of the cycle (see [PREREQUISITES.md](PREREQUISITES.md#docs-are-part-of-the-refactor)). Don't defer it to a follow-up. **But scope this to what *your change* broke** — a doc/command your move made wrong is in-scope; a doc/command that was *already* stale and sits **outside your move's blast radius** (e.g. a `scripts/test.sh` that names a test file deleted three cycles ago, which you didn't touch and your move doesn't depend on) is **flag-for-followup, not an in-PR fix** — folding it in is the scope creep the one-hat rule forbids. The test: did this cycle make it wrong, or is the cycle merely *near* something already wrong? Fix the former; record the latter.
+- **Removing your OWN now-dead scaffold is completing the move, not scope creep.** A temporary bridge you added earlier in the same multi-cycle move (a temp re-export/import, a transitional shim) that the current cycle makes dead should be deleted *in that cycle* — that's finishing the move you started, and the scope gate should accept it. This is the opposite of the "leave *inherited* artifacts alone" rule: you own this scaffold and the move isn't done until it's gone. (Reviewers and the scope gate can read it as creep — call it out in the cycle spec so it's clearly in-scope.)

--- a/skills/ops/refactor-codebase/GATES.md
+++ b/skills/ops/refactor-codebase/GATES.md
@@ -1,0 +1,104 @@
+# The Verification Gates
+
+This is the heart of the skill. The gates are what make an autonomous refactoring loop *trustworthy* instead of *plausible*. Each gate catches a different failure class; layer them, run cheap→expensive, **revert on the first red**.
+
+The governing rule: **the agent reports what the gate says, not what it thinks.** A gate is a script with an exit code. "Looks correct" is not a gate.
+
+## The ladder
+
+| # | Gate | Catches | Mechanism |
+|---|------|---------|-----------|
+| −1 | **Oracle validation** (pre-flight, once per target) | a green-but-worthless suite; "plausible but wrong" surviving where byte-identical can't apply | **mutation-test** the existing tests on the target (Stryker/mutmut/PIT); surviving mutants = unpinned behavior → write characterization tests to kill them *before* trusting the suite |
+| 0 | **Static** — compile / typecheck / lint | dropped imports, broken symbols, missed dynamic refs | compiler + linter exit code |
+| 1 | **Byte-identical API/bundle diff** | *any* unintended change in a "pure move" | diff the exported-symbol manifest or composed bundle against the pre-cycle snapshot — must be empty |
+| 1.5 | **AST node-count tripwire** | LLM "lazy coding": code silently dropped, elided, or replaced with `// ... unchanged` | a pure extraction/move preserves total AST node count across the affected files; a drop means code was elided → revert. Cheap, language-agnostic (any parser). From aider's refactor benchmark |
+| 2 | **Characterization / golden-master** | behavior drift where output isn't byte-stable | record outputs pre-cycle (fixed seed; scrub nondeterminism); re-run; compare; any delta → revert (**never** auto-accept a new snapshot) |
+| 3 | **Full existing suite** | regressions in covered behavior | exit 0; assert no skips were silently added |
+| 4 | **Scope & idempotency** | edits leaking outside the target domain; non-reapplying steps | assert no files changed outside declared paths; re-running the step is a no-op |
+| 5 | **Two-stage adversarial review** | logic the tests don't assert; scope creep; behavior smuggled into a structure cycle | fresh-context subagent sees only diff + spec; stage 1 spec-compliance, stage 2 quality |
+| 6 | **Deep-module quality** (the SELECTION acceptance test) | a "split" that made things shallower / leakier | interface width (exported symbols) vs implementation depth per new module; reject unless the interface narrowed, cross-boundary connascence dropped, or predicted change-amplification fell |
+
+Gate −1 is the gate most published refactoring tools lack the discipline to run: **prove the oracle catches bugs before relying on it.** A green suite is a false friend if it's weak. Gate 1.5 is the gate human refactorers don't need but agents do.
+
+## <a id="byte-identical"></a>Gate 1 — Byte-identical (the headline gate)
+
+For pure re-organization (barrel-split, compose-behind-factory, move-behind-facade) the **strongest and cheapest** oracle is an *empty diff*. If the refactor is genuinely structure-only, then:
+- the **public API surface** (the set of exported names + their shapes) is unchanged, and/or
+- the **composed/bundled output** is byte-identical.
+
+Use the **strongest equivalence check your toolchain supports** — pick from, ideally combine:
+- **Exported-symbol manifest** (works in every language): enumerate every public export of the affected entrypoints (names, and for typed languages their signatures/types). Sort, hash. Re-generate post-cycle; diff. This is the universal form. **If the module has import-time side effects** (opens a DB/socket, reads env on load) so you can't safely `import` it just to read `Object.keys`, enumerate the exports by **static-parsing the export statements (AST)** instead of importing — same manifest, no execution.
+- **Deterministic build/compile artifact** (strongest, where one exists): build/bundle/compile the entrypoint deterministically (mark deps external; disable minify, timestamps, and content hashing). Hash the output; re-build post-cycle; diff. Zero new build warnings is part of the gate. (For interpreted languages with no build step, lean on the manifest + AST checks instead.) **Sandbox caveat:** a locked-down environment (allow-scripts / no-postinstall) may leave a bundler like `esbuild` with its native binary un-installed, so this form simply **cannot run** — do not burn turns fighting it. The **manifest empty-diff + per-body byte-identical + AST no-shrink trio is a complete substitute** for Gate 1; the bundle hash is the strongest form *where available*, not a requirement.
+- **AST node-count invariant** (cheap corroboration, any language with a parser): a pure extraction preserves total AST node count across the affected files — a drop means code was elided. (From aider's refactor benchmark.)
+
+This gate is what most published refactoring tools *lack* — they gate on tests only. Lead with whichever form your stack supports; let tests corroborate.
+
+### <a id="surface-identical"></a>Gate 1b — surface-identical (NOT output-identical): the prerequisite-cycle variant
+
+Gate 1 (bundle hash `== 0`) and Gate 1.5 (AST node-count "preserved") assume a **pure move** — nothing added, only relocated. But the riskiest splits need a *setup cycle* first: a **branch-by-abstraction / Mikado leaf** that legitimately **adds** a little scaffolding (an indirection module, getters/setters, a re-export line) so the *next* cycle's move is safe. That setup cycle is behavior-preserving but **not** byte-identical: the bundle and the AST node-count both grow by the scaffolding you added. A literal reading of the headline gate red-lights a *correct* cycle, and an agent may wrongly revert it.
+
+For these surface-preserving-but-not-output-identical cycles, the real gate is:
+- **Exported-symbol manifest: empty diff** (the public surface is unchanged — this is non-negotiable), AND
+- **Moved/changed bodies byte-identical** where they were *moved* (diff each relocated body against its pre-cycle source), AND
+- **Behavioral gates green** (tests, characterization).
+- **Bundle hash and AST node-count: delta must be small and fully accounted-for** — every added node maps to a named piece of scaffolding in the cycle spec. Treat these as "minimal & explained," **not** "== 0." An *unexplained* delta is still a red. Note the AST invariant precisely: **gate on NO SHRINKAGE, not on an exact delta.** The node-count *grows* by an amount that scales with the number of re-export specifiers + import statements you added (seen in practice: +17 / +23 / +20 across cycles) — it is not a fixed number, so chasing an exact count is a rabbit hole. The AST gate's job is only "nothing was *elided*" (a drop ⇒ code dropped ⇒ revert). The gate that proves "nothing was *added or altered*" is the **byte-diff of each moved body against its pre-cycle source** (must be empty) — make that the definitive move-integrity gate; let AST cover shrinkage and the manifest cover the surface.
+
+> **Keep the move-integrity diff byte-exact — do NOT re-indent a moved body to "fix" its nesting.** When a technique re-nests a body (**compose-behind-factory** wraps it in `makeXApi(deps){ … }`, adding an indent level), the temptation is to re-indent to the idiomatic depth — but that turns every moved line into a diff hunk and forces you to *judge* "is this whitespace-only?" The robust doctrine: **leave the moved body at its original column inside the wrapper**, so `diff base head` over that body is a literal **zero-token, zero-whitespace** diff and stays a clean mechanical oracle. (Functions hoist; indentation depth ≠ scope, so under-indented bodies run identically.) Do **not** reach for `diff -w` to paper over re-indentation — whitespace *inside* multiline string literals is behavior, and `-w` would mask a real change there. The cost is cosmetic: the new module looks under-indented inside its factory. **Acknowledge that as deferred lint debt in the cycle log; do not fix it mid-cycle** (a reindent pass is its own separately-labeled cosmetic cycle, never smuggled into the structural one).
+
+Decide up front which variant a cycle is: a **pure move** gets `== 0`; an **abstraction-introduction leaf** gets "manifest empty + delta explained." State which one in the cycle spec's done-condition so the gate isn't ambiguous mid-run.
+
+### Reading a gate's result honestly — the runner's exit code can lie
+
+A gate is "a script with an exit code," but some test runners **emit a failure exit code (or a file-level "fail" line) on conditions that are not test failures** — e.g. an open handle / leaked process at exit, a forced-exit flag, a teardown warning. On such a toolchain `exit 0` is **not** a usable green signal: derive green from the **parsed report** (the per-test pass/fail tally), not from `$?`. Before trusting any runner as a gate, confirm what its exit code actually reflects on a known-green run; if the exit code and the tally disagree, gate on the tally and record the quirk in the masterplan's gate contract.
+
+### Regression vs flake (isolate before you blame the cycle)
+
+A "new" failure after your cycle is the single most likely thing to wrongly trip a revert — most "failures" on a real repo are pre-existing, not caused by you. Do not treat a full-suite delta as a regression on its face. Two discriminator arms; **run the base-sha arm FIRST — it is the more common answer:**
+- **Base-sha arm (do this first):** re-run the failing suite on the **pre-cycle base sha**. Fails *identically* on base → **pre-existing stable-RED** (missing AWS/S3/service stubs, env gaps), not your regression. Record it in the stable-red set; do not revert. On a real infra repo this is the answer the large majority of the time. **Switch to the base sha with a separate `git worktree add <tmp> <base-sha>` (preferred) or, only for a quick foreground run, `git stash -u` — NEVER a plain `git stash`.** Prefer the worktree: it is non-destructive to your working tree, so if the base-arm run is long or gets interrupted/killed (e.g. a backgrounded run), nothing is left in a half-stashed state needing a manual `git stash pop` to recover. A bare `git stash` leaves your cycle's *new untracked module* in the tree, so the "base" run executes the old caller against an orphan file — a false base reading (harmless when the orphan is unused; a silently-wrong verdict when the new file shadows a name). For any cycle that *adds* files, the base-sha arm must run against a tree that genuinely lacks them.
+- **Isolation arm (for nondeterministic suites):** if base-vs-head is inconclusive because the count *swings run-to-run* (server/DB-spawning suites that leak state), re-run the suite *in isolation*. Passes alone + full-run count inside the known flaky band → **flake**, not a regression. Record; do not revert. Note the failure mode: a leaky DB-spawning suite (PGlite, Testcontainers) run deep in a rapid sequence often returns a **wrong pass/fail count** (e.g. 6/2 where it should be 8/0), not a hang — so a surprising *count* mid-sweep is a flake signal, and re-running that one suite alone (a few times) is the fix. **On a stable-flaky suite, a SINGLE base-vs-head comparison is actively misleading** — a one-shot `86/37` head vs `85/38` base reads like a real +1 improvement until you run both arms 3× and watch each swing across an `80–86` band. Take **≥3 runs on BOTH arms and compare the bands, not the single counts**, before concluding regression-or-flake; a delta that stays inside the shared band is noise.
+- **Real regression** = fails on head but **not** on base, and reproduces in isolation → revert.
+
+Two recurring flake *classes* on service-spawning suites, distinct from a wrong pass/fail count: (a) **subprocess-startup timeout** — "gateway did not start on port X within Nms" when an integration test boots the whole app in a child process and the port-bind races under load; (b) **leaked-port / address-in-use** from a prior suite's un-reaped server. Both are environment/timing, not behavior. For a **pure move**, prefer an **in-process oracle** (e.g. an embedded-DB/PGlite test that drives the moved module in the same process) as the *authoritative* behavioral check, and treat heavyweight subprocess-spawn integration suites as corroboration only — a flaky port-bind must not make a byte-identical extraction look broken.
+
+This is why the **surface-identical / AST gate is the load-bearing oracle on a flaky-suite repo** (it's deterministic); the full suite corroborates per-target, in isolation. Record each target's isolated-green suites + the full-suite flaky band in the masterplan so the next cycle reuses the discriminator instead of re-deriving it.
+
+## <a id="oracle"></a>Gates 2–3 — Validate the oracle, then trust it
+
+A green suite is a **false friend if it's weak**. Two protections:
+- **Characterization tests** pin actual current behavior before you touch anything. They are not "correct behavior" tests — they capture *what is*, so any inadvertent change shows up as a diff. (Feathers; golden-master / approval testing.)
+- **Mutation-test the existing tests once, pre-flight** (where a mutation tool exists for your language — e.g. Stryker, mutmut, PIT; otherwise inject a few faults by hand and confirm the suite catches them). Surviving mutants are behavior the suite does not actually pin. Write characterization tests to kill them *before* refactoring. This is the gate that catches "plausible but wrong" when byte-identical doesn't apply (i.e. once you move beyond pure re-org).
+
+## Gate 5 — Two-stage adversarial review (grader ≠ worker)
+
+The agent that wrote the diff is the worst judge of it. Dispatch a **fresh-context** reviewer (a subagent if your harness has them; otherwise a cleared/new session) that sees only the diff and the cycle spec — not the reasoning that produced it.
+
+> **Pin the reviewer to the exact worktree.** On a shared workstation with multiple worktrees/clones of the same repo, a fresh reviewer will often default to reading a *sibling* checkout (e.g. the stale main checkout) and return a **false REJECT** — "phantom missing file," "symbol not found" — because it's looking at the wrong tree. Always give the reviewer the **absolute path of your worktree** and explicitly forbid it from reading any other checkout of the repo. (Cost when skipped: a full wasted review round-trip.)
+
+The two stages:
+- **Stage 1 — spec compliance:** does the diff do exactly what the spec said, nothing more? Flag scope creep, behavior changes smuggled into a structure cycle.
+- **Stage 2 — quality:** is the new module actually *deep*? Are names from the domain glossary? Any seam leaks?
+Each stage re-loops until it approves or rejects with a concrete reason. For higher assurance, use *N* independent reviewers prompted to **refute**, and require a majority to pass.
+
+## Gate 6 — Deep-module quality (did it actually improve?)
+
+Passing tests proves you didn't break it; it does not prove you *improved* it. A "split" that turns one 800-line file into ten 80-line files that import each other's internals has made the system **shallower** and *increased* change-amplification. Check, per new module:
+- exported-symbol count (interface width) — should be small
+- LOC behind it (implementation depth) — should be substantial
+- inbound coupling — callers depend on the narrow interface, not internals
+
+Reject splits that fail this even when tests pass. Depth, not line count, is the goal (Ousterhout).
+
+## Which gates run every cycle (no silent erosion)
+
+A subtle failure mode: the early cycles run the full ladder, then later "trivial" cycles quietly run a *lighter* set — drop a slow suite, skip the AST tripwire, skip the adversarial review — while the cycle log still reads "ran smoothly." Nothing breaks *this* time, but the trust contract has eroded and the next reviewer over-credits the weakly-gated cycles. Forbid this explicitly:
+
+- **Mandatory every cycle, no exceptions:** static/compile, the **exported-symbol manifest empty-diff** (Gate 1/1b), the **full must-stay-green suite contract** recorded in the masterplan (every suite in it, every cycle — not a convenient subset), and the **two-stage adversarial review**. These are the gates that catch the failures an agent can't see in its own diff.
+- **May be scaled to the move's risk** (e.g. characterization/golden-master for a pure verbatim 2-function move): only the gates whose failure mode the move provably cannot trigger. The bar is *provably cannot*, not *probably won't*.
+- **If you downgrade any gate, you must record WHY in the scoreboard row** ("ledger: 2 fns moved verbatim, golden-master N/A — no output path") so the downgrade is visible and auditable. An unrecorded downgrade is a gate violation, not a shortcut.
+- **The PR/impact evidence must be per-cycle**, never the first cycle's numbers carried forward as if they covered all of them (see [IMPACT.md](IMPACT.md)).
+
+## Failure semantics
+
+- On **any** gate red: **revert to the last green checkpoint.** Never stack edits on a red gate.
+- A cycle that can't pass a gate after a bounded retry is a **plan** problem — kick it back to the masterplan, don't brute-force.
+- The loop has three legitimate stops: success (worklist empty), blocked (record it), budget (cap hit). A missing failure-stop is how loops thrash on a broken state.

--- a/skills/ops/refactor-codebase/HANDOFF.md
+++ b/skills/ops/refactor-codebase/HANDOFF.md
@@ -1,0 +1,41 @@
+# The Handoff
+
+The handoff is what a **fresh session with no memory of the work** reads to resume the loop with zero ambiguity. (Reviews and resumes routinely happen in fresh context — design for it.) Often the masterplan already carries most of this; the handoff is the thin "where exactly we are and what's next" layer on top.
+
+Keep it **short and current**. A stale 500-line handoff is worse than a tight 40-line one. Refresh it at the end of every cycle.
+
+## Minimum contents
+
+```markdown
+# Handoff — <loop name>, cycle <N>
+
+## State
+- Masterplan: <link/path>. Branch: <branch>. Base: <origin/main sha>.
+- Last green checkpoint: <sha / tag>.
+- Worklist position: next target = <X> (technique <Y>).
+
+## Immediate next steps (the resuming agent starts at #1)
+1. <the very next action>
+2. ...
+
+## How to run the gates here
+- baseline suite: <exact command>
+- byte-identical snapshot: <exact command>
+- <any project-specific deploy/review step>
+
+## Gotchas (things that cost the last session time)
+- <env trap, flaky suite to filter, tool quirk, ...>
+
+## Open questions / blockers
+- <anything needing a human decision>
+```
+
+## Principles
+
+- **State in files, not chat.** The resuming agent must not need the prior conversation. If a fact matters, it's in the handoff or the masterplan.
+- **The next step is a concrete action, not a status.** "Resume decomposition" is useless; "Run cycle on `db.mjs` billing cluster via barrel-split; baseline command in §gates" is resumable.
+- **Carry gotchas forward.** The env trap that cost an hour this session will cost the next session an hour too unless it's written down. This is the highest-value part of the handoff.
+- **Mark soft claims as unverified.** Mechanical state (base sha, dir contents, gate commands, flaky band) is reliable to carry forward; *judgment* claims (which cluster is "green-tested" or "self-contained") drift and mislead. Tag them "claimed — verify via reverse-ref scan," and have the resuming agent re-run the scan rather than trust the prose. A confidently-wrong coverage claim can steer a bad cycle.
+- **One handoff, refreshed — not a pile.** Overwrite it each cycle (history lives in git + the scoreboard). Don't accrete `handoff-1`, `handoff-2`, … in the working set.
+- **Verify on resume.** The resuming agent re-reads the handoff, confirms the branch/sha and that the baseline is green, *then* starts step 1. If the recorded state doesn't match reality (drifted base, dirty tree), reconcile before refactoring.
+- **No handoff committed? Reconstruct from the tree.** When the prior loop kept its masterplan/handoff in scratch (the right call on a repo you don't own — see [MASTERPLAN.md](MASTERPLAN.md)), a fresh session won't find either. Don't start from zero: the repo *is* the handoff. A domain subdir + a re-export barrel means a decomposition is mid-flight — the extracted modules are done cycles, the still-inline clusters are the remaining worklist. Infer it, seam-rank the remainder, and write a fresh masterplan before cycle 1. (See SKILL.md → Orient.)

--- a/skills/ops/refactor-codebase/IMPACT.md
+++ b/skills/ops/refactor-codebase/IMPACT.md
@@ -1,0 +1,73 @@
+# The Impact Case: Selling the Refactor
+
+A refactor nobody understands the value of doesn't get merged. This file gives the agent (a) the **hard numbers** that make the general case and (b) a **per-PR impact report** that makes the specific case — so the dev, the lead, the PM, and the CTO each see value in their own unit.
+
+> **One-line thesis:** internal quality is not a speed-vs-quality tradeoff. The strongest evidence converges — unhealthy code is ~2× slower to change, ~15× buggier, and far less predictable, and firms that pay debt down grow revenue ~20% faster. As Fowler puts it, the cost of quality is **negative**.
+
+## The stat table (cite these; they're the credibility anchor)
+
+| Statistic | Figure | Source |
+|---|---|---|
+| Defects: unhealthy vs healthy code | **15× more** | CodeScene "Code Red" (peer-reviewed, 39 production codebases, arXiv 2203.04374) |
+| Time to resolve an issue in low-quality code | **+124% (~2×) longer** | Code Red |
+| Worst-case cycle-time (predictability) | **9× longer** | Code Red |
+| Developer time lost to tech debt / bad code | **23–42%** | Code Red / Stripe |
+| Dev hours/week fixing the past | **17.3 of 41.1 (~42%)** | Stripe, *The Developer Coefficient* (2018) |
+| "New product" budget diverted to debt | **~30%** | McKinsey, *Reclaiming Tech Equity* (220 orgs) |
+| Tech debt as share of tech estate value | **20–40%** | McKinsey |
+| Revenue growth: top vs bottom debt-managers | **+20%** | McKinsey |
+| Engineering time freed by managing debt | **up to +50%** | McKinsey |
+| US cost of poor software quality (2022) | **$2.41T** (debt ≈ $1.52T) | CISQ |
+| Developers' #1 frustration | **tech debt (62–63%)** | Stack Overflow Survey 2024 |
+| Window before poor quality slows you | **"a few weeks"** | Fowler, *Is High Quality Software Worth the Cost?* |
+
+The four most defensible anchors: CodeScene's **2× / 15× / 9×** (peer-reviewed, real code), McKinsey's **30% / 20–40% / +20%** (the money frame), Stripe's **42%** (the developer frame), Fowler's **negative cost of quality** (rebuts every "no time" objection).
+
+## Per-audience framing (same truth, their unit)
+
+- **Developers — "less friction, less fear, more flow."** They care about feedback speed, fear of breaking things, cognitive load. Pitch: "You're spending ~42% of your week fighting bad code; after this, changes here take half as long and break 15× less." Show before/after complexity + coverage from the actual PR — engineers trust numbers, not slogans. (Tech debt is *their* #1 frustration; only ~20% are happy at work.)
+- **Team lead / eng manager — "predictable velocity, less firefighting, lower bus-factor."** Pitch: "This hotspot swings cycle times up to 9×, which is why estimates miss. Stabilizing it cuts unplanned work and lets a new hire ramp in weeks not months." Metrics: 9× predictability gap, +50% reclaimed capacity, onboarding drag in dollars.
+- **Project manager — "fewer slipped deadlines, lower delivery risk."** Pitch: "Estimate misses here aren't the team's fault — low-quality code carries 9× worst-case variance. Reducing that variance is the most effective way to hit dates." Frame refactoring as **schedule insurance**, not gold-plating.
+- **CTO / CEO — "money, time-to-market, talent, growth."** Pitch: "Debt taxes ~30% of our new-product budget and equals 20–40% of our tech estate; firms that pay it down grow revenue ~20% faster. This converts hidden tax into roadmap capacity — and retains the seniors who quit over legacy code." Translate to dollars and strategic optionality, never code smells.
+
+## The per-PR impact report (attach to every refactoring PR)
+
+Pair *before/after objective metrics* with *projected business value*. Template:
+
+```markdown
+## Refactoring impact
+
+**Target:** <file/module> — selected as a churn × complexity hotspot
+(<N> commits in last 12mo × <complexity>), ranked #<k> in the repo.
+
+**Behavior preserved:** ✅ <suite> green (<n> tests); <byte-identical bundle / 
+golden-master diff empty / AST node-count unchanged>. No behavior change.
+
+| Metric | Before | After |
+|---|---|---|
+| Cognitive complexity (target) | … | … |
+| Public surface (exported symbols) | … | … (narrower = deeper module) |
+| Max function length | … | … |
+| Test coverage on surface | … | … |
+| Files touched per typical change (blast radius) | … | … |
+| Hotspot rank | #k | dropped out of top-N |
+
+**Projected value:** this hotspot accounted for ~<X>% of recent changes here;
+at the ~2× faster change-time multiplier for healthy code, expect ~<Y>
+engineer-hours/quarter reclaimed and lower defect risk in this area.
+```
+
+The headline is the **complexity/health delta + the behavior-preservation proof** — the first ties to the 2×/15× multipliers, the second is the trust anchor that answers "is refactoring risky?" for every skeptical reader.
+
+> **When a PR bundles several cycles, report behavior-preservation evidence PER CYCLE — never carry the first cycle's numbers forward as if they covered all of them.** "52 tests green, AST node-count unchanged" stated once for a three-cycle PR silently over-credits the later cycles if they actually ran a lighter gate set (and is exactly how a [silent gate downgrade](GATES.md#which-gates-run-every-cycle-no-silent-erosion) hides in a PR body). Give each cycle its own one-line evidence row — the suites it ran, its surface-diff result, whether it got an adversarial review — so a reviewer can see every cycle was gated, not just the first. If a cycle legitimately scaled a gate down for a provably-safe move, say so in that row; an honest "ledger: 2 fns verbatim, golden-master N/A" beats a blanket claim that doesn't hold.
+
+## Counterargument rebuttals (have these ready)
+
+| Objection | Rebuttal |
+|---|---|
+| "Refactoring is risky." | Behavior-preserving refactoring with a green oracle and small diffs is *lower* risk than continuing to change unhealthy code (15× defects, 9× variance). The risk is in *not* doing it. |
+| "It doesn't add features." | It adds future feature *capacity* — high internal quality reduces the cost of every future feature (Fowler). |
+| "We don't have time." | You're already paying ~42% of dev time / ~30% of budget. Poor quality slows you within "a few weeks." |
+| "Speed vs quality is a tradeoff." | DORA's multi-year data: elite teams achieve both; quality practices correlate with +50% delivery / +30% org performance. |
+| "Prove the ROI first." | Top-quintile debt-managers grow revenue ~20% faster; pair that with the specific before/after PR metrics above. |
+| "Let's do one big rewrite later." | Continuous small refactorings minimize risk vs big-bang; debt compounds and morale declines while you wait. |

--- a/skills/ops/refactor-codebase/MASTERPLAN.md
+++ b/skills/ops/refactor-codebase/MASTERPLAN.md
@@ -1,0 +1,60 @@
+# The Masterplan
+
+The masterplan is the **single source of truth** for the refactoring loop. It outlives any session. Keep it where the team already looks — a tracking issue (GitHub/Linear), or a `docs/refactor-masterplan.md` file checked into the repo. One masterplan per loop.
+
+> **On a repo you don't own (or a blind/dogfood run), don't commit the masterplan into the repo.** Adding an unsolicited planning doc pollutes a codebase whose conventions you haven't been invited to change. Keep the masterplan, gate-harness, and handoff in a **scratch dir outside the tree** (e.g. `/tmp/<repo>-refactor/`), and reference it from the PR rather than committing it. Commit *into* the repo only the durable artifact the project actually wants — a tracking issue, or a doc the maintainers asked for. (Fixing a *stale* doc your refactor touches is different — that's an in-PR change the repo wants; see [PREREQUISITES.md](PREREQUISITES.md#docs-are-part-of-the-refactor).)
+
+It answers four questions a fresh agent must be able to read off in 60 seconds:
+1. **Why** — the goal and the doctrine (the rules that don't change between cycles).
+2. **What's left** — the worklist, worst-first.
+3. **What's done** — the scoreboard, with evidence.
+4. **How** — the loop protocol and the gates (link to [CYCLE.md](CYCLE.md) / [GATES.md](GATES.md)).
+
+## Template
+
+```markdown
+# Masterplan: <goal in one line>
+
+## Goal & doctrine (settled — do not re-litigate per cycle)
+- **Trigger:** what makes something a target. Default to the evidence-based model in
+  [SELECTION.md](SELECTION.md): **churn × complexity hotspots**, cross-boundary
+  coupling (connascence / temporal coupling), and the high-signal smells (God Class,
+  Long Method). **Line count is a pre-filter only, never the trigger.**
+- **Axis:** how you split (e.g. "by domain/cohesion; background machinery becomes its
+  own sub-module, separate from interactive handlers"). Diagnose direction
+  (split vs consolidate) from the smell — see SELECTION.
+- **Ordering:** worst-first by **churn × complexity**, re-ranked each cycle.
+- **Risk posture:** prefer T1–T3 moves ([CATALOG.md](CATALOG.md)); treat god-file
+  splits (T5) as characterization-first, staged, reviewed work — not the default.
+- **Scope:** which dirs are in/out of scope.
+- **Quality bar (the acceptance test):** every change must make the design measurably
+  better — interface narrowed, cross-boundary connascence reduced, or predicted
+  change-amplification lowered. Reject any "split" whose halves still import each
+  other's internals (that is *shallower* and worse). Depth, not line count, is the goal.
+
+## Verification gates (the contract every cycle must pass)
+<link to GATES.md, and state the headline gate for THIS codebase —
+ e.g. "byte-identical esbuild bundle + full suite green">
+
+## Worklist (worst-first; re-ranked each cycle)
+- [ ] <target> (<size/metric>) — <candidate technique> — <one-line domain seam note>
+- [ ] ...
+
+## Scoreboard
+| Cycle | Target | Technique | Result | Evidence |
+|------|--------|-----------|--------|----------|
+|      |        |           |        |          |
+
+## Loop protocol
+<link to CYCLE.md; note any project-specific deploy/review steps>
+
+## Open questions / blockers
+- ...
+```
+
+## Notes on keeping it honest
+
+- **The metric is "fat files / debt remaining," not "lines moved."** Track the thing you actually want gone.
+- **Re-rank, don't pre-plan everything.** Earlier cycles change the terrain (a split can reveal or dissolve a later target). Re-run an `Explore` pass at the top of each cycle and update the worklist. Only the *doctrine* is fixed up front.
+- **Record refuted candidates.** If a target turns out to be a bad split (would widen interfaces, order is load-bearing, etc.), note it in the worklist as struck-through with the reason, or promote it to an ADR — so future re-ranks don't re-suggest it.
+- **One masterplan supersedes another cleanly.** When the goal changes, close the old plan with a pointer to the new one; carry forward the doctrine and scoreboard. Don't fork state.

--- a/skills/ops/refactor-codebase/PREREQUISITES.md
+++ b/skills/ops/refactor-codebase/PREREQUISITES.md
@@ -1,0 +1,78 @@
+# Pre-Flight: Prerequisites for Safe Refactoring
+
+**Run this BEFORE the masterplan, every time you start on a repo — especially a repo you don't own.** Refactoring is behavior-preserving by definition, and behavior preservation requires (1) an **oracle** you can trust and (2) a **reproducible environment** to consult it in. No oracle, no refactor.
+
+> Fowler's law: the two most important tools for refactoring are **self-testing code** and **continuous integration** — and "you aren't really doing continuous integration unless you have self-testing code." If the repo has neither, your first job is to establish an oracle, not to move code.
+
+## The decision rule
+
+After the checklist, every repo lands in one of three states:
+
+1. **HARD GATE — do not refactor.** No usable test oracle on the target surface AND it can't be cheaply characterization-tested; OR the suite is **genuinely** flaky; OR the build is **genuinely** red at baseline. → Bootstrap an oracle (golden-master tests, quarantine flakes) or STOP and report.
+
+> **First, rule out RED-vs-MIS-RUN — the hard gate's most common false trip.** A suite that fails on a fresh checkout is *usually* mis-run, not broken: it needs an undocumented env var, a service/DB stub, a seed, or a runner flag (or it *hangs* on a leaked handle, which a literal reading mistakes for "stuck → broken"). Aborting here on a healthy repo is the costliest pre-flight mistake. **Cheap discriminator:** bisect **one passing test vs one failing test** and diff their setup — if the only difference is environment (an env var, a stub, a fixture the failing test assumes), it's a **MIS-RUN → auto-bootstrap a run-wrapper** (state 2), not a red build. Only conclude "genuinely red" after the same minimal env makes a representative test pass. A *hanging* suite ≠ a *failing* suite: add a per-test timeout + force-exit and re-judge from the parsed tally before calling it flaky or broken.
+
+> **Stable-RED has a sibling: stable-FLAKY — and it does NOT mean STOP.** "Never refactor under a flaky oracle" (checklist #2) means *don't trust a flaky run as your green signal* — not *abort if the full suite is non-deterministic*. Real repos often have a whole suite whose fail count swings run-to-run (server/DB-spawning integration tests leaking state) that you cannot cheaply green. You can still refactor safely if you **(a)** make the deterministic **surface-identical / byte-identical / AST gate the load-bearing oracle**, and **(b)** pin a **per-target deterministic subset** (the unit suites that exercise the moved code, which pass reliably *in isolation*) as corroboration, judged via the regression-vs-flake discriminator ([GATES.md](GATES.md#regression-vs-flake-isolate-before-you-blame-the-cycle)). Record the full-suite flaky band + each target's isolated-green subset in the masterplan. This is AUTO-BOOTSTRAP (pin a trustworthy subset), not HARD-GATE STOP. Only a suite that is flaky *and* offers no deterministic subset *and* no surface gate (i.e. genuine behavior changes you can't byte-verify) is a true STOP.
+2. **AUTO-BOOTSTRAP (cheap, do it).** Missing canonical test entrypoint, `.tool-versions`/devcontainer, lint baseline, or seed determinism. → Generate them and point at the tool.
+3. **FLAG FOR HUMAN (expensive / owned).** No staging for an infra/backend refactor; no Docker for Testcontainers; low mutation score on a high-risk module. → Surface it; do not self-certify "done" without it.
+
+### The suite isn't green at baseline → which case is it? (one box)
+
+Four distinct diagnoses, only one is a STOP. Diagnose before you react — they look alike and the wrong call either aborts a healthy repo or refactors on a blind oracle:
+
+| Diagnosis | Tell | Action |
+|---|---|---|
+| **MIS-RUN** | fails on missing env/stub/flag, or *hangs* | bootstrap a run-wrapper (env + force-exit + timeout); re-judge from the parsed tally. NOT a stop. |
+| **Stable-RED** | fails **identically on the base sha** (run the base-sha arm) — missing AWS/S3/service backends in the harness | record the exact red set, assert it stays **unchanged**; the deterministic **surface/byte-identical gate is your oracle**. Proceed. |
+| **Stable-FLAKY** | fail count **swings run-to-run** (server/DB-spawning, state leaks) — incl. *miscount-under-load* | pin a deterministic per-target subset that passes **in isolation**; surface gate is load-bearing. Proceed. |
+| **Genuinely RED** | reproducibly broken on base AND no deterministic subset AND no surface gate (real behavior you can't byte-verify) | **HARD-GATE STOP** — bootstrap an oracle or report. |
+
+Stable-RED ≠ stable-FLAKY (different diagnosis — base-sha arm vs isolation arm — same escape hatch: lean on the deterministic surface gate). Full mechanics in [GATES.md](GATES.md#regression-vs-flake-isolate-before-you-blame-the-cycle).
+
+## The pre-flight checklist
+
+| # | Prerequisite | Why | How to detect | If missing |
+|---|---|---|---|---|
+| 1 | **Trustworthy test suite (oracle)** | can't prove behavior preserved without it | find `test/ tests/ spec/ __tests__ *_test.*`; run them | thin/absent → write **characterization / golden-master** tests on the public surface first |
+| 2 | **Deterministic suite (no flakes)** | a flaky suite is a non-oracle | run 3–5×, diff results; grep tests for `Date.now`, `random`, `sleep`, network | quarantine flakes; inject a clock, seed RNG, isolate state. **Never refactor under a flaky oracle.** |
+| 3 | **Oracle actually catches bugs** | green ≠ trustworthy; coverage tells you code *ran*, not that it's *asserted* | mutation test the target file (Stryker / mutmut / PIT); aim mutation score >70% | kill surviving mutants with characterization tests *before* trusting the suite |
+| 4 | **Reproducible dev env (one command)** | autonomous work must stand the project up identically every run | `.devcontainer/`, `docker-compose.yml`, `Dockerfile`, `flake.nix`/`devbox.json`, `.tool-versions`, `Makefile` | generate a `devcontainer.json` (image + features + `postCreateCommand` that installs deps and runs the suite) |
+| 5 | **Pinned runtime versions** | drift breaks the oracle | `.tool-versions`, `mise.toml`, `.nvmrc`, `engines`, `go.mod`, `rust-toolchain.toml` | create `.tool-versions` matching the CI matrix; Nix/devbox for polyglot |
+| 6 | **Deterministic test data** | integration oracle needs reproducible data | `db/seeds`, `factories/`, `fixtures/`, factory_bot/Fishery/factory-boy, unseeded Faker | add factories/fixtures; **seed Faker**; reset sequences between tests |
+| 7 | **Ephemeral DB / services for tests** | shared mutable state = flaky oracle | hardcoded `localhost:5432`? Testcontainers/in-memory present? | Testcontainers (real Postgres/Redis per run) or PGlite; avoid SQLite-in-memory when prod is Postgres (parity gap) |
+| 8 | **One canonical "run all tests" command** | the loop needs one unambiguous verify | `make test`, `npm test`, `Taskfile`, CI's test step | add one entrypoint wrapping the native runner (vitest/jest, pytest, `go test`, `cargo test`, rspec, JUnit). **Present-but-stale counts as missing** — see below |
+| 9 | **CI config as source of truth** | CI *is* the project's definition of correct; mirror it | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `Jenkinsfile` | replicate CI's exact commands/flags/versions locally (optionally `act`). Note: many pipelines merge upstream first — reproduce that |
+| 10 | **Static analysis baseline** | millisecond gates catch whole regression classes | `.eslintrc`, prettier, `ruff.toml`, `mypy.ini`, `tsconfig`, golangci-lint | record current warning count, fail only on **new** findings (refactor a noisy legacy repo without first cleaning it) |
+| 11 | **Clean build at baseline** | "preserved behavior" vs a broken build is meaningless | run the build | refuse to start until green |
+| 12 | **Staging / pre-prod (backend/infra)** | green tests can still hide prod-parity gaps (12-factor dev/prod parity) | staging deploy target? non-prod env config? | FLAG: staging evidence is a human-owned prerequisite before "done" |
+
+## Make the suite actually runnable
+
+(The step between "find the command" and "take the baseline.") The checklist's #8 covers a *missing* entrypoint. Real repos have a worse case: an entrypoint that **exists but is stale** — a `scripts/test.sh` / `make test` that names files long since renamed or deleted, a documented command that no longer runs the real suite. This is more dangerous than *missing*, because it looks authoritative while running nothing (or the wrong thing). Do not trust a documented command until you've confirmed it executes the real test files.
+
+Before taking a baseline:
+1. **Reconcile the documented command against reality.** List the actual test files (`find` for `*_test.*` / `*.test.*` / `*.spec.*`), then check the canonical command actually runs them. A command that runs 2 files when 70 exist is stale.
+2. **Build a working run-wrapper** (env vars + stub/seed + runner flags + per-test timeout/force-exit), and use *that* as your gate harness for the whole loop. On a repo you don't own, keep it in a scratch dir (not committed) unless you're fixing the repo's own command — see the docs rule below.
+3. **Confirm determinism on the wrapper** (run it 3–5×), then record the exact invocation in the masterplan's gate contract so every cycle verifies identically.
+4. **Watch for host/runtime gotchas in the wrapper itself** — they masquerade as a broken suite and burn turns. Record the ones you hit in the gate contract. Examples seen in the wild: ES modules ignore `NODE_PATH` (install gate deps into the package, e.g. `npm install --no-save`, don't rely on a global path); **a gate script that `import`s a dep (acorn/esbuild) must itself LIVE inside the package dir** — ESM resolves `node_modules` by walking up from the *script file's* directory, not the cwd, so a script in `/tmp` can't import a dep installed in `pkg/node_modules` even when you run it from `pkg/`; keep gate scripts in a gitignored scratch subdir *inside* the package (`pkg/.scratch/gate.mjs`) — but **verify it's actually ignored** (`git check-ignore pkg/.scratch/x`): a conventional-looking `.scratch/` is *not* ignored unless the repo's `.gitignore` says so, and if it isn't, a reflexive `git add -A` will stage all your gate artifacts into the PR. When in doubt, **stage the real files explicitly by path, never `git add -A`**, and check `git diff --cached --stat` before committing. Run the scope/leak check on the **staged set** (`git diff --cached --name-only | grep …`), not on `git status` — `git status` lists *untracked* scratch files too, which trips a false "scratch artifact is in the PR!" alarm when nothing is actually staged; `node --test <dir>` may need an explicit glob (`<dir>/*.test.mjs`) to discover files; macOS has no `timeout` (use the runner's own `--test-timeout`, `gtimeout`, or a `perl -e 'alarm shift; exec @ARGV'` wrapper); a relative path passed to a gate script (e.g. `./db.mjs`) resolves against the *script file's* dir under ESM import, not the invocation cwd — resolve it explicitly (`pathToFileURL(resolve(process.cwd(), arg))`); `node --test` reports pass/fail as `ℹ pass N` / `ℹ fail N` summary lines (not TAP `# pass`/`1..N`) — grep those when tallying from output. The class is general: the wrapper failing ≠ the code failing. **Harness hygiene over a long loop:** route per-suite/per-cycle test output to a single *reused* scratch file, not a growing pile of per-run logs — across dozens of cycles the accumulation can fill the harness tmpfs (ENOSPC) and kill the loop mid-run. Bigger hazard: **running the *entire* stable-red suite each cycle** (dozens of subprocess-spawning integration tests each timing out at 120s) is itself the main tmpfs/time sink — once you've recorded the baseline, run only the **deterministic per-target subset**, never the whole suite per cycle.
+
+## Docs are part of the refactor
+
+Read them; fix stale ones in the same PR. Reading the project's docs is **part of pre-flight**, not optional: `README`, test/setup docs, `CONTEXT.md`, `docs/adr/`, and whatever the canonical "how to run/verify" doc is. Two consequences:
+- **Read before you plan.** ADRs and the domain glossary record decisions you must not re-litigate and seams you should split along.
+- **A refactor that touches something the docs describe must update those docs in the *same* PR.** If pre-flight finds a doc that is *stale* (a dead test command, a renamed module, an obsolete setup step) and your refactor is in that area, **fix it in the same PR** — do not merely flag it as a follow-up. Stale docs are debt the refactor is uniquely positioned to pay down, and leaving them wrong re-pays the discovery cost onto the next agent. (A doc fix is a *behavior-preserving* change to the repo's documentation surface — it does not break the one-hat rule for code.)
+
+## What "bootstrap an oracle" means in practice
+
+When coverage on the target is thin (the common case on a god-file hotspot), **do not refactor first**. Instead:
+
+1. Pick the public surface of the target (its exported functions / API / rendered output).
+2. Write **characterization tests / golden-master snapshots** that capture what it does *today*, warts and bugs included. The trick: assert a deliberately-wrong value, run it, copy the *actual* observed output into the assertion. You're pinning current behavior, not asserting correctness.
+3. **Scrub nondeterminism** (timestamps, GUIDs, hash-ordered maps, absolute paths) so diffs reflect real change, not noise.
+4. Treat any later snapshot diff as a **hard stop** requiring justification — never auto-accept a new snapshot (that's how a regression gets "approved").
+
+Golden-master beats unit tests when behavior is poorly understood, coverage is thin, the output is large/structured, or you're exploring an unfamiliar codebase — exactly the autonomous-on-someone-else's-repo situation.
+
+## What this skill does NOT do
+
+It **flags and points**, it does not deeply build these for you. Standing up a full devcontainer, a Testcontainers harness, a seed library, or a staging environment are their own pieces of work. When a prerequisite is missing and expensive, the skill's output is a clear, specific recommendation ("this repo has no deterministic seed data; add Fishery factories + seed Faker before integration tests can serve as the oracle") — surfaced to the human, not silently worked around.

--- a/skills/ops/refactor-codebase/SELECTION.md
+++ b/skills/ops/refactor-codebase/SELECTION.md
@@ -1,0 +1,117 @@
+# Target Selection & Prioritization
+
+**This file decides WHAT to refactor and IN WHAT ORDER.** It is the engine that replaces gut-feel doctrine ("split anything over N lines") with evidence-based targeting. Pair it with [CATALOG.md](CATALOG.md) (which decides *how* — the move and its risk tier).
+
+> The single most important finding from the research behind this skill: **the popular "this file is long, split it" reflex is the least evidence-backed trigger and the most likely to do harm.** Length correlates with complexity but most long files are never touched, so refactoring them is pure cost. Target by *change pressure × complexity*, not by size.
+
+## The trigger function (use this, not line count)
+
+Trigger a refactor on a file/module only if it meets **at least one** of:
+
+1. **It is a hotspot** — high **churn × complexity**. Churn comes from `git log` (revision count, recent-window change frequency, distinct author count); complexity from cognitive complexity (preferred) or a cheap proxy. This is the primary signal.
+2. **It exhibits strong, distant, high-degree coupling** — connascence that crosses module boundaries (see ranking below), or **temporal/logical coupling** (files that repeatedly change together in the same commits → shotgun surgery).
+3. **It carries a high-signal smell** — chiefly **God Class / Large Class** or **Long Method**, the two smells most consistently linked to defects in the empirical literature. Other smells are weaker signals, often just proxies for length — treat them as conversation-starters, not mandates.
+
+**Line count is not the trigger** — but it is a first-class *secondary* objective for a different reason (agent-navigability), covered in its own section below. A 3,000-line file untouched in two years is a low *defect-ROI* target, yet may still be worth splitting so an agent can read it whole. An 800-line churning file is a top trigger target. Never split a file *because* it is long; split it because it's a churning hotspot, or because its size stops an agent from working safely — and only ever in a way the deep-module acceptance test approves.
+
+### How to compute the hotspot ranking (concrete)
+
+```
+# Churn: commits touching each file in a recent window (e.g. last 6-12 months)
+git log --since="12 months ago" --name-only --pretty=format: \
+  | grep -E '\.(js|mjs|ts|py|go|rb|java|rs)$' | sort | uniq -c | sort -rn
+
+# Cross with a complexity/size proxy per file; rank by (churn × complexity), worst first.
+# Distinct authors per file is an additional defect predictor (Nagappan et al.).
+```
+
+Where a real tool exists (CodeScene, `scc --by-file`, lizard for cognitive/cyclomatic complexity, `git-of-theseus`), prefer it. The principle is fixed; the tool is whatever the environment offers.
+
+> **Compute churn and size against `origin/<default-branch>` in a fresh worktree — never the local checkout.** On a shared workstation the local working copy is often parked on a stale or unrelated branch, where the very file you're ranking can be wildly different (seen in practice: a local `gateway.mjs` at 15,293 lines while `origin/develop`'s was 2,210 — a 7× phantom). Ranking or reading "the resume state off the repo tree" (SKILL.md step 0) against that stale tree mis-targets the whole cycle. `git fetch` first; run SELECTION, the size check, and the seam scan in a worktree cut from `origin/<default>`.
+
+### Temporal coupling (the shotgun-surgery detector)
+
+```
+# Files that change together reveal hidden coupling the source doesn't show.
+# For each commit, take the set of changed files; count co-occurring pairs;
+# the highest-frequency pairs that AREN'T obviously related are refactor targets.
+```
+
+This is the highest-signal smell you can mine from history rather than source.
+
+## AI-navigability: file size as a first-class *secondary* objective (the LLM-specific reason)
+
+The human refactoring literature demotes line count — and for *defect/maintainability ROI* that's correct (most long files are inert; churn × complexity is the real trigger). But an autonomous agent has a constraint a human reviewer does not: **it must hold a file in its context window to change it safely.** A file too large to read whole gets read in fragments, and fragmented editing is precisely what produces function duplication, silent drift, dropped references, and "lost in the middle" confusion — the exact failure classes the gates exist to catch. So for an *agent-maintained* codebase, file size is a real, first-class concern — just on a **different axis** than the trigger.
+
+Treat size on three distinct roles, and never confuse them with "long ⇒ split":
+
+1. **A constraint on process (always).** Read the **entire** target file before editing it. If it doesn't fit in one read, that is itself a risk signal — proceed only with extra care (chunk deliberately, map the whole symbol table first), and record it. An agent editing a file it has only seen in pieces is the highest-probability source of duplication/drift.
+2. **A secondary objective.** Bring files under a **context-friendly soft ceiling (~1,000 lines; aim lower where a clean seam exists)** so this agent and the next can operate whole-file. This matters *most* on fresh repos with no docs and no tests and many smells — where the agent is navigating blind and comprehension is the only safety margin it has. AI-navigability is an explicit, legitimate goal of this skill ("make a codebase more testable/AI-navigable").
+3. **A tiebreaker.** Among similarly-ranked hotspots, prefer the one too big to read whole.
+
+**The hard rule that keeps this honest:** size makes a file *operationally risky for an agent* and a *valid secondary target*, but it **never by itself justifies a split, and never dictates how to split.** The deep-module acceptance test below still governs: a context-friendly split that leaves the halves importing each other's internals is *classitis* — worse, not better. And the split's **output** must also respect the ceiling: don't carve a 4,000-line file into a tidy barrel plus a 2,000-line sub-file that the next agent still can't read whole.
+
+So the three signals compose: **churn × complexity** says a file is *worth* the effort; **size** says it's *operationally risky for agents and where unaided comprehension breaks down*; the **deep-module acceptance test** says a given split is *correct*. Use all three — don't let any one masquerade as the others.
+
+## Diagnose before you act: which DIRECTION?
+
+A trigger tells you *where*; the smell tells you *which way to move*. The two most common are opposites — get this wrong and you make it worse:
+
+| Diagnosis | Smell | Root cause | Correct direction |
+|---|---|---|---|
+| One module changes for **many unrelated reasons** | **Divergent Change** | low cohesion | **SPLIT** — extract by reason-to-change |
+| One change forces edits across **many modules** | **Shotgun Surgery** | excessive coupling | **CONSOLIDATE** — move/inline together |
+| A method uses another type's data more than its own | **Feature Envy** | misplaced behavior | **MOVE** behavior to the data |
+| Domain concept encoded as raw primitives everywhere | **Primitive Obsession** | weak types | **INTRODUCE** type / parameter object |
+
+At small scale the usual failure is *over-decomposition* (the right move is often to **merge** shallow files and deepen, not split). At large scale the failure is *misallocated effort* (let churn × complexity pick the ~3% that matters).
+
+## Ranking coupling rigorously: connascence
+
+"Coupling is bad" is too blunt to drive decisions. Connascence ranks it. Two elements are connascent if changing one forces a change in the other. Evaluate on three axes — **strength**, **degree** (how many entities), **locality** (how close).
+
+Strength, weakest → strongest: **Name → Type → Meaning → Position → Algorithm** (static) → **Execution → Timing → Value → Identity** (dynamic). Static is always weaker than dynamic (you can find it by reading source).
+
+Action rules:
+- **Attack strong + distant + high-degree connascence first** — that is exactly what produces shotgun surgery.
+- Strong connascence is acceptable **when local** (same function/class). Don't refactor local strong coupling; refactor it when it crosses a boundary.
+- **Convert** strong→weak where it crosses boundaries (Position→Name via named params / a parameter object; dynamic→static where possible).
+
+## The acceptance test: did the refactor actually improve the design?
+
+Passing tests proves you didn't *break* it; it does not prove you *improved* it. A "split" that turns one 800-line file into ten 80-line files importing each other's internals is **shallower** and worse (Ousterhout's *classitis*). Before accepting any structural change, require **at least one** to be demonstrably true:
+
+1. **The interface narrowed** — fewer exported symbols / parameters relative to implementation (a *deeper* module). Compare public-surface size before/after.
+2. **Cross-boundary connascence dropped** — strong/distant/high-degree coupling reduced or localized. The new boundary **hides** information; it does not leak internals.
+3. **Predicted change-amplification fell** — the next likely change now touches fewer places (use historical co-change as the predictor).
+
+If none hold, you moved code, you didn't refactor. **Reject the split.** Specifically reject any split where the two halves still import each other's privates — that manufactures a wide, leaky boundary.
+
+## Metric choices (so the agent doesn't guess)
+
+- **Prefer cognitive complexity over cyclomatic.** Cyclomatic measures testability (paths) and is nearly redundant with LOC; it ignores nesting and over-counts flat `switch`es. Cognitive complexity (SonarSource) tracks understandability better — but it too is only modestly validated, so use it as a signal, not gospel.
+- **Use LOC only as a pre-filter / tiebreaker**, never standalone.
+- **Churn × complexity is the primary prioritizer.** Distinct-author count is a useful secondary defect predictor.
+
+## Scale guidance for selection
+
+| Scale | Dominant failure mode | What to target | What to de-prioritize |
+|---|---|---|---|
+| **Small (<10k LOC)** | over-decomposition / classitis | deep-module audit; consolidate shallow files; method-level smells (Long Method, Feature Envy) | churn analysis (too little history); aggressive splitting |
+| **Medium (10k–100k)** | emerging god-classes, growing coupling | cognitive complexity + cohesion within hotspots; begin churn×complexity ranking | global LOC thresholds |
+| **Large (100k+/monorepo)** | misallocated effort on the inert long tail | churn×complexity hotspots + temporal coupling, worst-first; chunk big changes into independently-tested diffs | auditing every large file — most are inert |
+
+## Once a file is picked: rank the intra-file seams
+
+Churn × complexity tells you *which file* to attack; it does **not** tell you *which seam inside it to extract first* — and on a god-file split that order is load-bearing. Pulling the wrong cluster first can force you to export a shared internal (widening the surface) or land you on a cluster with no test coverage to prove the move safe. Within the chosen file, rank candidate clusters by **self-containment × existing-green-test coverage**, and extract the **most-provable first**:
+
+- **Self-containment** — how few shared internals (a private `pool`, a module-level cache, a helper several clusters use) the cluster touches. A cluster that closes over shared mutable state is *not* a clean first move; untangle that shared state in a setup cycle first (see the shared-mutable-state trap in [TECHNIQUES.md](TECHNIQUES.md)).
+- **Green-test coverage** — a cluster already exercised by a green suite gives you a behavioral gate for free; extract it before clusters that only the byte-identical manifest can vouch for. Early cycles should be the *safest to prove*, building a trail of green checkpoints before you reach the gnarlier seams.
+- **Run the reverse-reference scan per candidate cluster** (grep every symbol across the file + all importers) to see what it shares before you commit to the order. **Trust the scan over any handoff/masterplan prose about coverage or cohesion** — inherited notes drift; the scan is ground truth.
+- **Extract-the-wedge-first.** When an *unrelated* block sits wedged between two halves of a cohesive cluster, extract the wedge first: it makes the target cluster contiguous, so the next cycle becomes a trivial verbatim slice instead of two scattered moves. Spotting the wedge is a direct payoff of re-ranking every cycle (the terrain that looked like one hard cluster is often one easy wedge + one easy remainder).
+
+This produces a within-file worklist: easiest-and-best-covered first, shared-state untangling as an explicit setup cycle, the leaky/entangled clusters last. Record it in the masterplan worklist, re-ranked each cycle like everything else.
+
+## Re-rank every cycle
+
+Earlier cycles change the terrain (a split can reveal or dissolve a later target). Re-run a quick selection pass at the top of each cycle and update the worklist. Only the *doctrine* (this file) is fixed up front; the worklist is not.

--- a/skills/ops/refactor-codebase/SKILL.md
+++ b/skills/ops/refactor-codebase/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: refactor-codebase
+description: Autonomously refactor a codebase across many verified cycles — decompose fat files by domain, deepen shallow modules, pay down architectural debt — driven by a persistent masterplan and behavior-preserving gates. Use when the user wants to refactor at scale, split god-files, decompose a large module, run an ongoing architecture-improvement loop, or do a multi-session refactor that must not change behavior. Complements (does not replace) improve-codebase-architecture, which only finds and reports opportunities.
+---
+
+# Refactor Codebase
+
+Run a **behavior-preserving refactoring loop** over a codebase: confirm the repo is safe to refactor (**pre-flight**), discover and rank the work into a **masterplan**, execute it as discrete **cycles** (one verified change each), prove each change preserved behavior, and **hand off** cleanly so any fresh session can resume. Built for the case `improve-codebase-architecture` can only point at: actually *doing* the refactor, safely, over many sessions, on codebases you may not own.
+
+The unit of progress is **one cycle = one structural change, proven not to alter behavior, committed in isolation.** Slow is smooth, smooth is fast — one clean cycle beats five half-finished branches.
+
+## The prime invariant (non-negotiable)
+
+> **Never commit or hand off a state where the build is red, the behavior oracle diffs, or the public surface changed unintentionally.**
+
+Three corollaries:
+- **One hat per cycle** (Beck). A cycle changes *structure* OR *behavior*, never both. Refactoring keeps observable behavior identical. A bug you find mid-cycle gets *recorded* and fixed in a separate, labeled, behavior-changing change — never smuggled into a structure cycle. This is the #1 discipline failure for LLM agents.
+- **Plausible ≠ correct.** An edit that *looks* right but drops one import in a nested module ships a runtime failure. Every edit is a *proposal*, accepted only when a deterministic gate (script/test exit code) says so — never on the model's own judgment.
+- **No oracle, no refactor.** You cannot prove behavior preserved without a trustworthy test oracle. If the repo has none, establishing one is the work — see [PREREQUISITES.md](PREREQUISITES.md).
+
+If you cannot define "done" for a cycle as a **binary, bounded, runnable check** before you start it, you are not ready to start it.
+
+## When to use / not use
+
+**Use** for: splitting a god-file, decomposing a large module by domain, an ongoing "pay down the hotspots" loop, untangling tightly-coupled modules, making a codebase more testable/AI-navigable — at a scale that spans multiple sessions.
+
+**Don't use** for: a single small edit (just do it), a behavior change / bug fix (that's not refactoring — wear the other hat), or merely *finding* opportunities without executing (use `improve-codebase-architecture` and stop).
+
+## What targets, and why NOT just "big files"
+
+The instinct to "split files over N lines" is the **least evidence-backed trigger** for defect/maintainability ROI, and often makes designs worse. Target by **churn × complexity** (hotspots), **cross-boundary coupling** (connascence / temporal coupling), and the two high-signal smells (God Class, Long Method) — not by size alone. **But size is still a first-class *secondary* objective for a reason humans don't have: an agent must hold a file in its context window to change it safely** — a file too big to read whole drives duplication and drift, which matters most on fresh repos with no docs or tests. So aim files under a context-friendly soft ceiling (~1,000 lines) *as a goal*, while letting churn×complexity *prioritize* and the deep-module acceptance test *govern how*. And remember the risk ladder: **splitting a god-file is the riskiest tier (T5)**, not a reflex. The full target model (and how these three signals compose) is in [SELECTION.md](SELECTION.md); the move menu and risk tiers are in [CATALOG.md](CATALOG.md).
+
+## Three artifacts (state lives in files, never in chat)
+
+Context windows have a smart zone (early) and a dumb zone (late); conflating workflow state with session state breaks resumption. So all durable state is external:
+
+1. **Masterplan** — the persistent plan + doctrine + scoreboard. A file or tracking issue. See [MASTERPLAN.md](MASTERPLAN.md).
+2. **Cycle log** — what each cycle did + its evidence. Appended to the scoreboard. See [CYCLE.md](CYCLE.md).
+3. **Handoff** — the minimal note a fresh session reads to resume. See [HANDOFF.md](HANDOFF.md).
+
+## <a id="environment"></a>Adapt to the environment and toolchain (do this first)
+
+This skill is language-, toolchain-, and environment-agnostic. The forms in these files (`.mjs`, `export *`, an esbuild hash, `git`) are **illustrative**, not requirements. Before the loop, detect and adapt:
+
+**1. Isolation — match it to where you're running.** The requirement is only ever *a clean baseline and a one-command revert*.
+- **Ephemeral box (sandbox, devbox, CI container, throwaway VM):** you own the machine — **work directly on a branch, no worktree.** Use everything it offers: start services, seed the DB, run integration/e2e, hit real ports. Revert = `git reset --hard` / re-checkout.
+- **Shared workstation (a personal computer with other work in progress):** use a **worktree or dedicated clone** so the loop can't disturb other branches and parallel cycles can't collide.
+
+**2. Toolchain — discover the project's real verification affordances; use all of them.** Do **not** assume `tests/` or `npm test`. Find how *this* project proves itself correct (its real test command incl. integration/e2e, DB seeds/fixtures, linter/type-checker/formatter, build system, services it needs, and especially its **CI config** — the canonical "how this project verifies itself") and wire those into your gates. Full detection + bootstrap guidance in [PREREQUISITES.md](PREREQUISITES.md).
+
+Map every gate and technique to your stack's equivalent (Python `__init__` re-exports, Go package split, a public-API snapshot tool, a deterministic compiler artifact). The concepts — deep modules, facade/barrel, byte-identical surface, characterization tests — are universal; only the commands change.
+
+## The loop
+
+### 0. Orient (every session)
+Read the project's docs — `README`, `CONTEXT.md` / glossary, `docs/adr/` (ADRs record decisions you must not re-litigate), and the canonical "how to run/verify" doc. Reading docs is part of the work, not a nicety: they name the seams to split along and the commands your gates depend on. **If a doc your refactor touches turns out to be stale** (a dead test command, a renamed module, an obsolete setup step), **fix it in the same PR** — never just flag it for later ([PREREQUISITES.md](PREREQUISITES.md#docs-are-part-of-the-refactor)). Look for an existing masterplan or handoff. **If one exists, resume from its next unchecked item.** If not, **read the resume state off the repo tree itself**: a domain subdir beside a fat file (`db/` next to `db.mjs`) plus a barrel of `export … from "./db/*"` lines *is* an in-flight decomposition — the already-extracted modules are completed cycles, and the clusters still inline in the fat file are the remaining worklist. Reconstruct the worklist by seam-ranking what's left ([SELECTION.md](SELECTION.md#once-a-file-is-picked-rank-the-intra-file-seams)) rather than re-deriving from zero or (worse) re-extracting an already-moved cluster. Then bootstrap the masterplan from that inferred state (steps 0.5 → 1).
+
+### 0.5 Pre-flight — is this repo safe to refactor? ([PREREQUISITES.md](PREREQUISITES.md))
+Before planning any move, run the pre-flight checklist and apply its decision rule: **hard-gate** (no/flaky oracle, red build → bootstrap an oracle or STOP), **auto-bootstrap** the cheap missing pieces (test entrypoint, version pins, lint baseline, seed determinism), and **flag for human** the expensive/owned ones (staging for infra refactors). Validate the oracle itself with mutation testing before you trust it. **No oracle → no refactor.**
+
+### 1. Masterplan — discover & rank the work ([SELECTION.md](SELECTION.md))
+Fan out read-only `Explore` subagents to map the codebase. Rank targets by **churn × complexity** (from `git log`) crossed with cohesion/coupling signals — not by line count. Diagnose each candidate's *direction* (split vs consolidate) from its smell. Record the masterplan: the doctrine (from SELECTION), the ranked worklist, the gates ([GATES.md](GATES.md)), and an empty scoreboard. Do **not** pre-commit a rigid plan for every file — re-rank from a fresh `Explore` pass each cycle.
+
+Optional for risky (T4/T5) targets: **Mikado discovery** — attempt the move, record what breaks as prerequisites, then **revert**. Repeat until the leaves are safe to execute. The graph *is* the plan and the handoff. See [TECHNIQUES.md](TECHNIQUES.md#mikado).
+
+### 2. Cycle — execute one verified change ([CYCLE.md](CYCLE.md))
+- **a. Pick** the worst-first hotspot and the **technique by risk tier** ([CATALOG.md](CATALOG.md)) — prefer T1–T3 moves; treat T5 god-file splits as characterization-first, staged work.
+- **b. Pin behavior.** Establish the oracle *before* editing: green baseline + a captured API-surface / bundle snapshot. If coverage is thin, write characterization tests first (validated via mutation testing). See [GATES.md](GATES.md).
+- **c. Implement** from a clean baseline with one-command revert. Prefer a fresh subagent handed the cycle spec. Prefer **semantic tools** (LSP move/rename; codemods: ast-grep / jscodeshift / comby) over hand text-edits on large files; otherwise move bodies **verbatim**.
+- **d. Run the gate ladder** (cheap→expensive, revert on any red): static → **byte-identical API/bundle diff** → **AST node-count tripwire** → characterization/golden-master → full suite → scope & idempotency → **two-stage adversarial review** (fresh-context grader ≠ worker) → **deep-module quality check** (did the interface narrow? — the SELECTION acceptance test). Full ladder in [GATES.md](GATES.md). Run the **mandatory** gates every cycle — including the "trivial" ones; any gate scaled down for a provably-safe move must be **recorded with a reason in the scoreboard**, never silently dropped.
+- **e. Commit** one unit. Update the scoreboard. **On any red: revert to the last green checkpoint — never patch forward.**
+
+### 3. Impact, handoff & loop
+Produce the **per-PR impact report** ([IMPACT.md](IMPACT.md)) so reviewers and stakeholders see the value in their own unit. Refresh the handoff/scoreboard so the next session resumes unambiguously. Then continue to the next cycle.
+
+## Autonomy & stopping criteria
+
+Every loop needs three explicit stops, or it thrashes:
+- **Success stop** — worklist empty / target metric reached.
+- **Blocked stop** — unrecoverable after bounded retry (incl. a failed hard-gate: no oracle and can't bootstrap one). Record the blocker in the handoff and surface it.
+- **Budget stop** — max cycles / token cap; hand off cleanly.
+
+## Distribution
+
+`npx skills add`-installable. To publish: place this directory in a public GitHub repo and share `npx skills add <owner>/<repo> --skill refactor-codebase`. Validate locally with `npx skills add .`.
+
+## Reference files
+- [PREREQUISITES.md](PREREQUISITES.md) — pre-flight: the oracle + environment, with hard-gate/bootstrap/flag decision rule
+- [SELECTION.md](SELECTION.md) — what to target & in what order (churn×complexity, connascence, the deep-module acceptance test)
+- [CATALOG.md](CATALOG.md) — the refactoring menu, T1–T5 risk ladder, expected findings/effort/diff/scale
+- [MASTERPLAN.md](MASTERPLAN.md) — masterplan format + scoreboard
+- [CYCLE.md](CYCLE.md) — the per-cycle protocol
+- [GATES.md](GATES.md) — the verification ladder (the heart of the skill)
+- [TECHNIQUES.md](TECHNIQUES.md) — barrel-split, compose-behind-factory, strangler, branch-by-abstraction, extract, Mikado, LSP-move
+- [IMPACT.md](IMPACT.md) — the business case + per-PR impact report
+- [HANDOFF.md](HANDOFF.md) — handoff document format

--- a/skills/ops/refactor-codebase/TECHNIQUES.md
+++ b/skills/ops/refactor-codebase/TECHNIQUES.md
@@ -1,0 +1,102 @@
+# Techniques
+
+Each technique is a *named, mechanical* move with a known safety profile. Pick by the shape of the target. The first two keep the change **byte-identical at the public surface**, which is why they're the workhorses of a behavior-preserving loop.
+
+> **Reach for a semantic tool before hand-editing.** Where the language has one, prefer an **LSP "move/rename"** or a **codemod** (ast-grep / jscodeshift / comby) over text edits — it updates every call site, import, and type atomically and eliminates the dropped-reference failure class. This is *the* safety lever: approachability tracks determinism (see [CATALOG.md](CATALOG.md)). Hand-editing is the fallback for languages/moves with no tool, and it leans on the reverse-reference scan + the AST node-count tripwire ([GATES.md](GATES.md)).
+
+> **Language-agnostic.** Examples below use JS/Node syntax (`export *`, `makeXApi(deps)`) and `git` for illustration. The moves are universal — map them to your stack: a "barrel" is a re-export facade (Python `__init__.py` re-exporting submodules, a Go package's exported surface, a Java package-info/facade, a Rust `mod.rs` `pub use`); "compose-behind-factory" is any constructor/provider that assembles sub-providers; "revert" is whatever gives you a clean rollback in your VCS. Keep the *public surface* identical; the mechanics are local.
+
+## Barrel-split — for pure-export / helper modules
+
+A big module that is mostly independent exported functions (a `utils`, a `db`, a helpers file).
+
+1. Split the file into `<dir>/<domain>.mjs` sub-files, grouped by cohesion.
+2. Replace the original file with a **barrel** that re-exports them:
+   `export * from "./<dir>/identity.mjs"; export * from "./<dir>/billing.mjs"; …`
+   The `export … from` line is self-documenting — **do not annotate it with process comments** ("extracted in cycle 3", "re-exported so importers stay unchanged"). That story lives in the commit/PR, not the source (see [CYCLE.md](CYCLE.md#cycle-hygiene)).
+3. Every importer keeps its original `import { … } from "<original>"` unchanged.
+
+**Why it's safe:** the public import path and surface are untouched → the byte-identical *manifest* gate is trivially satisfiable. Note the equivalence is **manifest-identical, not bundle/AST-identical**: extracting to a new file always adds an import + a barrel re-export line, so the bundle and AST node-count *grow* by that scaffolding — gate them with the surface-identical variant ("delta small & explained," not `==0`), see [GATES.md](GATES.md#surface-identical). Watch for **shared internals** (a private helper several domains use): move it to `<dir>/_core.mjs` and have the domain files import it. Before deciding move-vs-share, grep every moved symbol across the original file + all importers (the reverse-reference scan).
+
+### The shared-mutable-state trap (the crux of splitting a DB/service god-file)
+
+The most common reason a barrel-split *looks* trivial but isn't: many of the functions you want to move all read a **private, mutable, module-level binding** via closure — a `let pool` (the DB connection), a `let cache`, a `let _ready` flag — assigned in some `init()` and read by ~everything. This is **connascence of state through a shared mutable binding**: strong, and (once you split) *distant*. A naive move breaks two ways:
+- the moved sub-file can't see the private binding → **won't compile**; or
+- you "fix" that by **exporting** `pool` from the original file → the public surface widens, the module gets *shallower*, and you **fail the deep-module acceptance test** (Gate 6). The barrel was supposed to hide internals, not leak them.
+
+So the move-vs-share decision the reverse-reference scan feeds isn't only about helpers — it's about **shared mutable state**, and the fix is a dedicated holder, not a wider export:
+
+1. **Introduce a private holder module** (`<dir>/_state.mjs` / `_pool.mjs`) that owns the mutable bindings and exposes them as **live bindings + setters** — in ES modules: `export let pool = null;` plus `export function setPool(p){ pool = p; }`. The `init()` core writes via the setters; every other module **imports the live binding** and reads the current value (ES live bindings update at the import site when the holder reassigns — verify your language has this semantic; in CommonJS/Python you'd export a getter `() => pool` or a small holder object instead).
+2. **Do this as its own setup cycle first** (a branch-by-abstraction / Mikado leaf) — *before* moving any domain functions. It legitimately changes the bundle (the setters + import), so it's gated with the **surface-identical variant**, not byte-identical ([GATES.md](GATES.md#surface-identical)).
+3. **Then the domain extractions are pure verbatim moves** — each carved-out module imports the live `pool`/`ready` from the holder, the original file's public surface stays byte-identical, and `_state.mjs` is **not** re-exported from the barrel (it's a private internal, which is exactly what keeps the module deep).
+
+This sequence — *untangle shared mutable state into a private live-binding holder, then move* — is what makes splitting any connection-pooled DB layer or stateful service module safe. It's the worked form of "inject deps as getters" from compose-behind-factory, applied to a barrel-split.
+
+**Shared *immutable* constants are a lighter case — don't over-engineer them with a holder.** A `const COLS = "..."` (or any frozen value) shared by two clusters you're separating doesn't need setters or a live-binding holder; nothing reassigns it. Either move it *with* the cluster that owns it and have the other import it, or — when two non-contiguous regions split across separate cycles both need it — use a **temporary private re-import bridge**: the first cycle exports the const from its new module, the second imports it, and once both regions have moved you collapse the const into its final private home. Reserve the holder+setters pattern for state that is genuinely *mutated at runtime*; for immutable shared values a plain move/import is the behavior-preserving fix.
+
+## Compose-behind-factory — for factory / handler modules
+
+A fat `makeXApi(deps)` (or class) that builds and returns many handlers.
+
+1. Split into per-domain sub-files, each exporting `makeX<Domain>(deps)` that returns its slice of handlers.
+2. The original factory **composes** them: it calls each sub-factory and merges the returned handler objects.
+3. Callers keep `import { makeXApi } from "<original>"` and the same wiring.
+
+**Why it's safe:** the factory's external contract (its returned shape) is unchanged → byte-identical surface. Watch for deps that are *reassigned at runtime* (e.g. via a reload): inject them as **getters** (`() => dep`), not captured values, or the sub-module sees a stale binding.
+
+**The load-bearing safety check when you wrap the factory in a lazy singleton** (`let _api; const api = () => (_api ??= makeXApi(deps))`): a lazy holder is behavior-preserving **only if the factory does no observable work at construction time.** Probe explicitly — *does `makeXApi` invoke any injected, side-effecting dep in its body (not inside a returned handler)?* If it just destructures deps and returns closures (the common case), lazy-init is invisible. But if it *eagerly calls* a side-effecting dep (opens a connection, constructs a client, fires a request) at construction, the lazy holder shifts **when** that side effect fires — from module-load to first-use — which can be observable. Safe-by-default holds when the injected deps are themselves already lazy/memoized (e.g. a `getClient()` that self-memoizes on first await); confirm that, don't assume it.
+
+## Extract module — for one cohesive cluster inside a bigger file
+
+When a fat file has one clear domain you can lift out.
+
+1. Identify the cluster: functions sharing state/types/tables, called together.
+2. Move them verbatim into a new module; export the minimal surface the rest of the file needs.
+3. Re-import that surface back into the original. Keep the moved bodies **byte-identical** (slice, don't retype).
+
+**The shared-mutable-state trap applies here too**, not just to barrel-split: if the moved cluster closes over a module-local binding (a `let COSTS_DB`, a cached handle assigned in some `init()`), you must re-home that binding. Re-declare the same-named binding inside the new module and add a single `initX(args)` setter the host calls at the same point the old inline init ran (see the holder pattern above). One extra rule when the **host keeps its own derived value** from that init (e.g. a `const HAS_SQLITE = sqliteAvailable()` the host reads elsewhere): have `initX()` **set the module-local AND return the derived value**, and have the host assign its const from that return — *one* evaluation, so the module's copy and the host's const **cannot diverge**. Recomputing the flag independently on the host side is the bug this avoids. (This is the lightweight, single-module form of the live-binding holder — use it when only one host consumes the state; promote to a separate `_state.mjs` holder when several modules do.)
+
+Prefer **language-server "move symbol"** / codemods so every call site and import updates atomically. The deletion test confirms the cluster was worth extracting: if deleting the new module would re-scatter complexity across callers, it's earning its keep.
+
+## Strangler-fig — for risky replacement of a live path
+
+When you must replace a behavior, not just relocate it.
+
+1. Stand up the new implementation **beside** the old, behind a seam (adapter / feature flag).
+2. Route consumers to it **incrementally**, one at a time; run both in parallel and verify equivalence.
+3. Once all traffic is on the new path and verified, delete the old.
+
+This is a *behavior* change track — it gets behavior gates (golden-master, staging/canary), not just byte-identical.
+
+## Branch by Abstraction — the in-process strangler
+
+When the thing to replace is **deep in the stack** (upstream callers you can't intercept at a perimeter), use Branch by Abstraction instead of Strangler-fig:
+
+1. Introduce an **abstraction** capturing the client↔supplier interaction; route **all** clients through it.
+2. Build the new implementation behind the same interface (optionally behind a feature flag); the system **builds and runs correctly at all times**.
+3. Switch clients over progressively; remove the old supplier, then possibly the abstraction.
+
+This is the in-process analog of strangler-fig, and it maps almost exactly onto **compose-behind-factory**: split a fat module behind a stable interface, build the new internals, verify identical output, retire the old. Use it for large structural changes on trunk without a long-lived branch.
+
+## <a id="mikado"></a>Mikado discovery — for "I don't know what will break"
+
+To **discover** a safe decomposition order empirically instead of guessing:
+
+1. Attempt the change you want (the goal).
+2. Note everything that breaks. Those are **prerequisites** — children of the goal in the graph.
+3. **Revert** the attempt (`git reset --hard` / discard). The tree stays green.
+4. Recurse into each prerequisite until you reach a **leaf**: a change that breaks nothing.
+5. Execute leaves bottom-up, each as its own green-verified cycle.
+
+**Why it's powerful:** the breakage *tells you* the dependency structure — no upfront guessing. The Mikado graph (checked/unchecked nodes) doubles as the masterplan and the handoff. The discipline that makes it work: **never commit a broken attempt; revert and record instead.**
+
+## Choosing
+
+| Target shape | Technique | Gate emphasis |
+|---|---|---|
+| exported-helpers file | barrel-split | byte-identical surface |
+| `makeXApi` / handler factory | compose-behind-factory | byte-identical surface |
+| one domain inside a fat file | extract module | byte-identical + reverse-ref scan |
+| replace impl deep in the stack | branch-by-abstraction | byte-identical surface, then golden-master |
+| behavior must change (perimeter) | strangler-fig | golden-master + staging |
+| unknown breakage | Mikado (then one of the above per leaf) | revert-on-red |


### PR DESCRIPTION
## What this skill does

\`refactor-codebase\` runs a **behavior-preserving refactoring loop** over a codebase:

1. **Pre-flight** — confirm the repo is safe to refactor (clean tree, green baseline, oracle available)
2. **Masterplan** — discover and rank the work (trigger = churn × complexity, not raw line count)
3. **Cycles** — execute as discrete cycles, *one verified structural change each*, proven not to alter behavior, committed in isolation
4. **Gates** — verification gates (oracle validation, AST node-count tripwire) prove each change preserved behavior
5. **Handoff** — clean handoff so any fresh session can resume the campaign

The unit of progress is **one cycle = one structural change, proven not to alter behavior**. It's built for the case \`improve-codebase-architecture\` can only point at: actually *doing* the refactor, safely, over many sessions, on codebases you may not own.

10 files: SKILL, SELECTION, CATALOG, PREREQUISITES, CYCLE, GATES, TECHNIQUES, MASTERPLAN, IMPACT, HANDOFF.

## Why it's a fit

Every skill in this library is battle-tested in real production workflows before publishing. This one was **dogfooded over 5 production iterations on Pylot** — the masterplan epic decomposed Pylot's fat gateway down across many extraction cycles, each shipped behavior-identical to prod.

## Namespace rationale: \`ops/\`

The repo deliberately uses three namespaces — \`meta/\` (skills about skills), \`product/\` (PRDs/planning), and \`ops/\` (CI, auditing, code-health, evidence). \`refactor-codebase\` is an operational **code-health** workflow and sits naturally alongside the existing \`ops/\` engineering skills: \`entropy-check\` (quality grading), \`docs-review\` (drift detection), \`security-check\`, and the various runners. Inventing a fourth namespace (\`eng/\`) for a single skill would fragment the convention; \`ops/\` is the cleanest existing fit for a behavior-preserving refactor runner.

## Conventions followed
- Read \`meta/skill-builder\` (authoring standard) and \`meta/migrate-skill\` (canonical local→repo move procedure) first
- Placed at \`skills/ops/refactor-codebase/SKILL.md\` so \`npx skills add\` resolves it
- Added a catalog row to the \`ops\` table in \`README.md\` matching the existing format
- Vercel-standard frontmatter only (\`name\`, \`description\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)