### PR TITLE
fix(build-train): replace dangling wait-for-job.sh ref with chunked PID poll (#1482)

### DIFF
--- a/skills/ops/build-train/stages/02-build-fanout/CONTEXT.md
+++ b/skills/ops/build-train/stages/02-build-fanout/CONTEXT.md
@@ -67,7 +67,18 @@ WORKER_LOG="$WORKER_LOG_DIR/${WORKER_SESSION}.log"
 ) &
 WORKER_PID=$!
 ```
-Use `scripts/wait-for-job.sh` to block until the worker exits.
+Block until the local worker exits — but poll its PID in short **foreground chunks**, never
+`wait "$WORKER_PID"` in one call. A worker turn can run for many minutes, and any Bash command
+past the harness's ~120s tool timeout is auto-backgrounded and then **killed ~5s after your turn
+ends** (pylot#1482), orphaning the work. Re-run this chunk until it prints `worker DONE`:
+
+```bash
+# ~96s chunk: poll the worker PID every 8s; exits early when it dies.
+for _ in $(seq 1 12); do kill -0 "$WORKER_PID" 2>/dev/null || break; sleep 8; done
+kill -0 "$WORKER_PID" 2>/dev/null && echo "worker RUNNING — run this chunk again" || echo "worker DONE"
+```
+
+(The previously-referenced `scripts/wait-for-job.sh` never existed.)
 
 ### Verify + fix the PR
 1. Find the PR the worker created:


### PR DESCRIPTION
## Fix: build-train's dangling `wait-for-job.sh` ref (a latent #1482 trap)

`build-train` stage-02 spawns a local `claude -p … &` worker (`WORKER_PID`) then instructs: *"Use `scripts/wait-for-job.sh` to block until the worker exits."* Two problems:
1. **`scripts/wait-for-job.sh` never existed** in any repo (verified across pylot + both skill repos).
2. The obvious substitute — `wait "$WORKER_PID"` — is the **#1482 trap**: a worker turn runs for minutes, exceeds the harness's ~120s Bash timeout, is auto-backgrounded, and gets **killed ~5s after the operator's turn ends**, orphaning the build.

Replaced with a self-contained **`<120s` foreground PID-poll chunk** the operator re-runs until `worker DONE` (early-exits when the PID dies). No missing script, no long blocking wait.

### Scope note
This PR fixes the one **genuine bug** in the dogfooded wait loops. The remaining items from the unification audit are **dedup, not bugs**, and are deferred to a focused follow-up because they carry real risk/complexity:
- `pylot-workers` Step 3 worker-poll → `pylot-await --worker`: it's the **shared** poll imported by speckit/deps/release-train (changes output-capture for all three; `--worker` is bats-validated but not yet live-validated).
- `speckit-runner` staging-validation build/health loops: run in **worker context** (different image), so they need `await.sh` shipped as a skill *asset*, not the baked `pylot-await`.
- `vercel-deploy` (JSON `state==READY`) + `image-builder` stage-02 (raw CodeBuild) need new `await.sh` modes (`--expect-field`, `--codebuild`).

Companion to pylot-skills#19 (test-in-staging → pylot-await) and pylot#1581 (the backstop + `pylot-await`, live on prod).
