### PR TITLE
chore(skills): tombstone pylot-workers → pylot-cli; update referencing skills (epic #2834 child 17, #2833 closeout)

### DIFF
--- a/skills/ops/deps-runner/SKILL.md
+++ b/skills/ops/deps-runner/SKILL.md
@@ -15,7 +15,7 @@ to the monolithic `deps-runner` skill, just stage-partitioned.
 
 **This skill runs in the OPERATOR session** and owns its worker lifecycle. Stages that
 require a repo environment (preflight, build-test) spawn and drive a repo devbox worker via
-the gateway worker API (see `pylot-workers` skill). Stages that only need `gh` CLI
+the gateway worker API (see `pylot-cli` skill, § Workers). Stages that only need `gh` CLI
 (scan-context, risk-eval, merge-decision, report) run inline in the operator session.
 
 **This procedure is SEQUENTIAL. There is NO fan-out and NO parallel Task launches.** Risk
@@ -38,7 +38,8 @@ SPAWN_RESP=$(curl -s --max-time 90 -X POST \
 WID=$(echo "$SPAWN_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("worker_id",""))' 2>/dev/null)
 ```
 
-Use the `pylot-workers` drive loop pattern to send each repo-access stage as a prompt and
+Use the `pylot-cli` drive loop (§ Workers → Drive; the raw-`curl` form above is § Workers →
+Fallback when there is no usable CLI) to send each repo-access stage as a prompt and
 poll to idle before proceeding to the next stage. Stop the worker before stage 06-report:
 
 ```bash

--- a/skills/ops/flowchad-runner/SKILL.md
+++ b/skills/ops/flowchad-runner/SKILL.md
@@ -87,7 +87,8 @@ runs in the operator turn. Attempting `chromium.launch()` in the operator turn f
 carrying no screenshots. The dispatching automation's context already says *"Use qa worker."*
 
 `pylot.qa` and `booster-pack.qa` — the operators that carry `flowchad-runner` — carry
-`pylot-workers` and `evidence-upload`, which is everything the operator side needs. They do
+`pylot-cli` (the injected baseline, so it is on every operator) and `evidence-upload`, which is
+everything the operator side needs. They do
 **not** need `playwright` or `visual-evidence` installed: the browser requirement belongs to the
 worker image, not the operator.
 

--- a/skills/ops/flowchad-runner/stages/03-walk-flows/CONTEXT.md
+++ b/skills/ops/flowchad-runner/stages/03-walk-flows/CONTEXT.md
@@ -39,7 +39,8 @@ Anything else is `blocked`. **Never** substitute a curl/static probe for a walk.
 
 ### Spawn the worker (only when at least one flow prefers `playwright`)
 
-Follow the **pylot-workers** lifecycle (spawn → prompt → poll-to-idle → stop). Spawn once
+Follow the **pylot-cli** § Workers lifecycle (spawn → prompt → poll-to-idle → stop; the
+raw-`curl` form below is its § Workers → Fallback when there is no usable CLI). Spawn once
 and reuse it for every playwright flow; do **not** stop it here — stage 04 uploads from the
 same worker and owns the `stop` call.
 

--- a/skills/ops/issue-to-prd/shared/prototype-mission-brief.md
+++ b/skills/ops/issue-to-prd/shared/prototype-mission-brief.md
@@ -23,7 +23,7 @@ that shape.
 
 1. **No browser in this container.** The operator image (`Dockerfile.operator`) ships no chromium,
    no `libnss3`, no ffmpeg. Everything — build, boot, screenshot — runs on a **worker devbox**,
-   driven through the `pylot-workers` API (spawn → prompt → poll-to-idle → stop). Do not try to
+   driven through the `pylot-cli` § Workers API (spawn → prompt → poll-to-idle → stop). Do not try to
    install a browser here.
 2. **Branches only. Do not open pull requests.** Three PRs would fire `review-pr-on-opened` three
    times, then `double-check`, then FlowChad, then CTO review — a full review pipeline spent on

--- a/skills/ops/issue-to-prd/stages/05b-prototype-gate/CONTEXT.md
+++ b/skills/ops/issue-to-prd/stages/05b-prototype-gate/CONTEXT.md
@@ -75,9 +75,14 @@ team = os.environ["TEAM"]
 d = json.load(sys.stdin); teams = d.get("teams", d)
 ops = next((t for t in teams if t.get("name") == team), {}).get("operators", {})
 cand = [(r, s.get("skills", [])) for r, s in ops.items() if "prototype" in s.get("skills", [])]
-cand.sort(key=lambda rs: "pylot-workers" not in rs[1])
+cand.sort(key=lambda rs: rs[0])
 print(f"{team}.{cand[0][0]}" if cand else "")')
 ```
+
+This used to tie-break toward whichever candidate also carried `pylot-workers`, i.e. the one
+that could drive a worker devbox. Since pylot #2833 step 3 the injected baseline is `pylot-cli`
+and **every** operator carries it, so worker-driving no longer discriminates — the tie-break
+would always be a no-op. Sorting by role name instead just keeps the pick deterministic.
 
 `$TEAM` is the repo's managing team. Do **not** use `pylot context <org/repo>` for this — it
 returns `team: null` and an empty `operator.skills` for repos whose team binding it cannot

--- a/skills/ops/pylot-workers/SKILL.md
+++ b/skills/ops/pylot-workers/SKILL.md
@@ -1,108 +1,40 @@
 ---
 name: pylot-workers
-description: Use as a baseline import in operator skills that drive repo devbox workers — documents spawn, prompt, poll, and stop lifecycle.
+description: DEPRECATED — worker spawn/drive/stop moved into pylot-cli. Read pylot-cli instead; this skill is a pointer and carries no instructions.
 user-invocable: false
 ---
 
-# pylot-workers — Worker API Reference
+# pylot-workers — DEPRECATED, use `pylot-cli`
 
-Every operator has this skill loaded as a baseline. Worker-driving skills
-(`speckit-runner`, `deps-runner-proc`, `release-train-runner-proc`) use these
-endpoints to spawn and drive a repo devbox worker via the gateway.
+**Superseded by [`pylot-cli`](../pylot-cli/SKILL.md) on 2026-08-03 (pylot #2833 / epic #2834).**
+This skill is kept only so the name stays resolvable for anything that still
+references it. It carries no instructions — do not follow it, do not add to it.
 
-All calls require `Authorization: Bearer $PYLOT_DISPATCH_TOKEN`.
-Gateway base: `$PYLOT_API` (or `$PYLOT_GATEWAY_URL`).
-Mission ID: `$PYLOT_JOB_ID`.
+## Why
 
----
+`pylot-workers` existed because it was the *injected baseline* skill on every
+operator, so it was the only reliable place to document the worker API. Since
+pylot #2833 step 3 the injected baseline is `pylot-cli`, and `pylot-cli` absorbed
+the full worker lifecycle. Two documents describing the same API is how they
+drift, so there is now one.
 
-## 1. Spawn a worker
+## Where it went
 
-```bash
-SPAWN_RESP=$(curl -s --max-time 90 -X POST \
-  -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"repo\": \"$REPO\"}" \
-  "${PYLOT_API}/missions/${PYLOT_JOB_ID}/workers")
-WID=$(echo "$SPAWN_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("worker_id",""))' 2>/dev/null)
-```
+| You wanted | Now read |
+|---|---|
+| spawn a worker | `pylot-cli` § Workers → **2. Spawn** |
+| queue a prompt / drive a turn | `pylot-cli` § Workers → **3. Drive** |
+| poll to idle | `pylot-cli` § Workers → **3. Drive** (`--wait`, or poll `view` until `turn_state` is terminal **and** `turn_seq` ≥ the prompt's seq) |
+| stop / resume | `pylot-cli` § Workers → **4. Stop (destructive) and resume** |
+| the raw `curl` drive loop | `pylot-cli` § Workers → **7. Fallback when there is no usable CLI** — same routes, same semantics |
+| what a mission operator's token may call | `pylot-cli` § Workers → **6. What your credential can call** |
 
-Returns `{"ok": true, "worker_id": <number>}` (201) or an error body.
-`WID` is the worker row id used in all subsequent calls.
+`pylot-cli` covers ground this skill never did: repo preflight before spawn
+(`pylot devboxes project`), typed spawn failures, the mission-scope rule
+(`--mission "$PYLOT_JOB_ID"` inside a mission, or 403), multi-box relay, and
+never busy-polling in a chat/Lambda runtime.
 
----
+## If you are here from a skill or an assignment row
 
-## 2. Queue a prompt
-
-```bash
-PROMPT_RESP=$(curl -s --max-time 30 -X POST \
-  -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"prompt\": \"$PROMPT\"}" \
-  "${PYLOT_API}/missions/${PYLOT_JOB_ID}/workers/${WID}/prompt")
-TURN_SEQ=$(echo "$PROMPT_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("turn_seq",""))' 2>/dev/null)
-```
-
-Returns `{"ok": true, "turn_seq": <number>}` (202) or 409 if the worker is busy.
-Always capture `turn_seq` — it's the handle for polling.
-
----
-
-## 3. Poll to idle
-
-Poll until `turn_state == "idle"` AND `turn_seq == TURN_SEQ`.
-
-```bash
-WORKER_EXIT=""; POLL_EL=0; POLL_MAX="${PYLOT_WORKER_POLL_MAX:-2400}"
-while [ "$POLL_EL" -lt "$POLL_MAX" ]; do
-  sleep 15; POLL_EL=$((POLL_EL + 15))
-  ST=$(curl -s --max-time 20 \
-    -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" \
-    "${PYLOT_API}/missions/${PYLOT_JOB_ID}/workers/${WID}")
-  ST_LINE=$(echo "$ST" | python3 -c '
-import sys, json
-try: d = json.load(sys.stdin)
-except: d = {}
-ec = d.get("last_exit_code")
-print("%s|%s|%s" % (d.get("turn_state",""), d.get("turn_seq",""), "" if ec is None else ec))
-' 2>/dev/null)
-  W_STATE="${ST_LINE%%|*}"; W_REST="${ST_LINE#*|}"; W_SEQ="${W_REST%%|*}"; W_EC="${W_REST##*|}"
-  if [ "$W_STATE" = "idle" ] && [ "$W_SEQ" = "$TURN_SEQ" ]; then WORKER_EXIT="$W_EC"; break; fi
-done
-```
-
-`last_output` in the final `$ST` response contains the worker's turn output (capped at 16 KB tail).
-The executor stale-turn reaper sets `exit_code=-1` if the devbox dies mid-turn, so this never
-hangs past the reaper window.
-
----
-
-## 4. Stop the worker
-
-```bash
-curl -s --max-time 30 -X POST \
-  -H "Authorization: Bearer $PYLOT_DISPATCH_TOKEN" \
-  "${PYLOT_API}/missions/${PYLOT_JOB_ID}/workers/${WID}/stop" >/dev/null 2>&1 || true
-```
-
-Idempotent. Always call stop when the skill is done — even if the turn failed.
-The harvest backstop also stops workers, but explicit stop is faster and cheaper.
-
----
-
-## Drive loop pattern
-
-```
-spawn → prompt(phase1) → poll-to-idle → check output →
-        prompt(phase2) → poll-to-idle → check output →
-        ...
-        stop → emit [pylot] outcome= marker
-```
-
-Between phases, read `last_output` from the final poll response to detect
-phase-level failures before sending the next prompt.
-
-Emit the outcome marker AFTER stopping the worker:
-```
-[pylot] outcome="<summary>" status=<success|partial|failed|blocked>
-```
+Update the reference to `pylot-cli`. `pylot-cli` is the injected baseline on
+every operator, so it is always loaded — no assignment row is needed for it.

--- a/skills/ops/release-train-runner/SKILL.md
+++ b/skills/ops/release-train-runner/SKILL.md
@@ -12,7 +12,7 @@ one PR at a time, in order. Run the full test suite after each merge. Produce on
 with conflicts documented and a unified manual test plan, plus a local report.
 
 **This skill runs in the OPERATOR session** and owns its worker lifecycle. It spawns a repo
-worker devbox via the gateway worker API (see `pylot-workers` skill) and drives stages 01-06
+worker devbox via the gateway worker API (see `pylot-cli` skill, § Workers) and drives stages 01-06
 through the worker. Stage 00 (claim compute) and stage 07 (report + outcome marker) run
 inline in the operator.
 
@@ -34,7 +34,8 @@ SPAWN_RESP=$(curl -s --max-time 90 -X POST \
 WID=$(echo "$SPAWN_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("worker_id",""))' 2>/dev/null)
 ```
 
-Drive each stage as a separate prompt using the `pylot-workers` drive loop pattern. Poll to
+Drive each stage as a separate prompt using the `pylot-cli` drive loop (§ Workers → Drive; the
+raw-`curl` form above is § Workers → Fallback when there is no usable CLI). Poll to
 idle between stages. Stop the worker after stage 06 completes, before the inline stage 07
 writes the report and emits the outcome marker:
 


### PR DESCRIPTION
Part of fellowship-dev/pylot#2834 (child 17). Refs fellowship-dev/pylot#2833

Deprecation closeout for `pylot-workers`. pylot #2833 step 3 swapped the injected operator baseline to `pylot-cli` (pylot PR #2855, live on prod as sha `8fb7f2be2735`), and `pylot-cli` absorbed the full worker lifecycle in #117. This retires the old document.

## (a) Runtime verification — the gate for this PR

The checklist says *if (a) fails, STOP*. It did not fail. Evidence, all read-only, taken after the prod deploy:

**a.1 — composed operator views (`pylot teams list`, all 33 operators across 16 teams)**

| Check | Result |
|---|---|
| `pylot-cli` at `skills[0]` | 33/33 operators |
| `pylot-cli` appears exactly once | 33/33 (`cli_count=1` everywhere) |
| `lexgo.cto` — carries an *explicit* `pylot-cli` row — no duplicate | confirmed: `pylot-cli, cto-review, speckit-runner, …` (single entry) |
| Teams with no `pylot-workers` anywhere in the composed view | `booster-pack.{cto,designer,dev,qa}`, `lexgo.{cto,dev}`, `pylot.{cto,dev,qa}`, `tooling.{cto,dev}`, `firmavirtual-fv.dev`, `fvl-copycat.dev`, `website.dev` |

Injection confirmed at source: `gateway/gateway.mjs:478` `BASELINE_OPERATOR_SKILL = "pylot-cli"`, prepended with `Set`-dedupe at `gateway.mjs:558` — which is why the explicit row on `lexgo.cto` cannot double up.

**a.2 — fresh mission boot**

The only mission that started after the deploy is `post-deploy-smoke_8fb7f2b` (`pylot.ops`, created 23:08:32Z). Its boot markers:

```
boot_skills lookup=ok http=200 configured=9 materialized=9 team=pylot role=ops org=fellowship-dev
boot_integrity token=operator-jwt skills=9/9 identity=1 skills_lookup=ok
```

9/9 configured skills materialized, `skills_lookup=ok`, zero skill-resolution errors. That count matches the composed list for `pylot.ops` exactly (`pylot-cli` + 8 stored). The swap composes and materializes cleanly.

The mission then reported `failed`, and that failure is **pre-existing and unrelated**: it dies at `phase=route action=no_skill` because the #2708 smoke task is prose ("reply with OK and finish") with no `/skill` prefix, which `scripts/operator.sh:369` fail-fasts on by design. The same job failed identically on the two prior deploys, both **before** the baseline swap:

| smoke job | created | status |
|---|---|---|
| `post-deploy-smoke_652d4f2` | 2026-08-02 18:44Z | failed exit=1 |
| `post-deploy-smoke_ddd6c69` | 2026-08-03 09:46Z | failed exit=1 |
| `post-deploy-smoke_8fb7f2b` | 2026-08-03 23:08Z | failed exit=1 |

Not caused by the swap, and worth its own issue: the #2708 liveness check can never pass the deterministic-routing gate.

*Could not verify:* no post-deploy mission has yet booted an operator that carries **no** stored `pylot-workers` row, so the clean-boot evidence comes from an operator that still has one. The composed-view evidence in a.1 covers all 33 regardless.

**a.3 — `worker_scope_required` denial scan** (child 20's fence, in this release)

**0 denials.** 180-minute lookback (deploy ~23:05Z), across every gateway log group: `pylot-gateway-api`, `pylot-llm-proxy`, `pylot-gateway-processor`, `pylot-gateway-executor`, `pylot-gateway-ingress`. Control greps (`REPORT`, `RequestId`) return 5 on the same query, so the zero is a real zero and not a broken filter. No legitimate caller has tripped the new fence.

## (b) Tombstone

`skills/ops/pylot-workers/SKILL.md` content → a deprecation pointer with a where-it-went map. The **directory and the frontmatter `name` are unchanged**, so the catalog row stays resolvable and the 19 operators that still carry a stored assignment (see (d)) resolve to a harmless pointer rather than a missing skill.

Nothing is lost: `pylot-cli` § Workers covers spawn/drive/stop, and its §7 fallback documents the identical raw-`curl` routes this skill held. `pylot-cli` also covers ground `pylot-workers` never did — repo preflight (`pylot devboxes project`), typed spawn failures, the `--mission` scope rule, multi-box relay, and the no-busy-poll rule for chat/Lambda runtimes.

## (c) Reference-by-reference swap

The checklist named `deps-runner`, `release-train-runner`, `drive-worker`. **There is no `drive-worker` skill in this repo** — that premise is wrong. The actual referrers, re-derived by grep, are four skills / eight references:

| File | What the reference actually does | Change |
|---|---|---|
| `deps-runner/SKILL.md:18` | doc pointer for the worker API | → `pylot-cli` skill, § Workers |
| `deps-runner/SKILL.md:41` | "use the `pylot-workers` drive loop pattern" between stages | → `pylot-cli` § Workers → Drive; notes the inline raw-`curl` above maps to § Workers → Fallback |
| `release-train-runner/SKILL.md:15` | doc pointer for the worker API | → `pylot-cli` skill, § Workers |
| `release-train-runner/SKILL.md:37` | drive-loop pattern between stages 01-06 | → `pylot-cli` § Workers → Drive; same fallback note |
| `flowchad-runner/SKILL.md:90` | **factual claim** about what `pylot.qa` / `booster-pack.qa` carry | Claim was already **false** post-swap — neither operator carries `pylot-workers`. Restated as `pylot-cli`, which is the injected baseline and therefore guaranteed present |
| `flowchad-runner/stages/03-walk-flows/CONTEXT.md:42` | lifecycle pointer before the spawn snippet | → `pylot-cli` § Workers lifecycle + fallback note |
| `issue-to-prd/shared/prototype-mission-brief.md:26` | lifecycle pointer for the prototype mission | → `pylot-cli` § Workers API |
| `issue-to-prd/stages/05b-prototype-gate/CONTEXT.md:78` | **executable code**, not a pointer: `cand.sort(key=lambda rs: "pylot-workers" not in rs[1])` — tie-breaks candidate roles toward one that can also drive a worker devbox | A literal swap to `pylot-cli` would be a **guaranteed no-op**, since every operator carries the baseline — dead code that reads as meaningful. Replaced with `cand.sort(key=lambda rs: rs[0])` to keep the pick deterministic, with the reason recorded inline |

Verification on the one touched fenced block: `bash -n` OK, and the embedded Python `compile()`s.

## (d) Explicit `pylot-workers` assignment rows — NOT a no-op; blocked

Child 16's probe reported *zero* explicit stored rows. That reading was taken while the injected baseline was still `pylot-workers`, so stored and injected were indistinguishable in the composed view. Post-swap the stored rows are visible, and `GET /teams/_db` (normalized records, no runtime composition) confirms:

**19 of 33 operators carry a stored `pylot-workers` assignment row.**

| Written | Operators |
|---|---|
| `2026-07-21 22:07:57.749023` — identical to the microsecond, one bulk backfill (13 rows) | `clapes.cto`, `clapes.dev`, `firmavirtual-fv.lead`, `inbox-angel.{cto,dev,marketing,scout}`, `lexgo-infra.cto`, `lexgo-marketing.marketer`, `mtg-lotr.{cto,dev}`, `navvi.{cto,dev}` |
| `2026-07-30` (6 rows) | `lexgo.product-owner`, `pylot.{analyst,architect,ceo,intern,ops}` |

Identical-microsecond timestamps across 13 rows, plus `pylot-workers` sitting at index 0 of nearly every stored array, make these unambiguously the legacy-baseline artifact rather than user intent.

**The prescribed removal command cannot remove them.** `gateway/modules/teams/teams-api/skills.mts` `parseStoredOperatorSkills()` filters `pylot-workers` out of the stored array *before* the handler compares — so `handleRemoveOperatorSkill` computes `present === false`, skips the `upsertOperator` write entirely, and returns `removed:false`. Verified live against `mtg-lotr.cto`:

```
$ pylot teams skills-remove mtg-lotr cto pylot-workers --force
{"ok":true,...,"removed":false,"skills":["cto-review","speckit-runner","deps-runner","create-compelling-prs","issue-to-prd"]}
```

The response array shows `pylot-workers` already absent — but re-reading `/teams/_db` afterwards shows the DB row **unchanged** (`updated_at` still `2026-07-21 22:07:57.749023`, `pylot-workers` still first) and the count still 19. Zero mutation. `handleAddOperatorSkill` gates its write on `!already`, so it cannot trigger the scrub either.

Net: the composed runtime view leaks `pylot-workers` into 19 operators' skill bundles, and neither sanctioned endpoint can clean it. **No mutations were made.** This PR's tombstone makes the leak harmless — those operators now load a pointer, not a stale API doc — but the rows themselves need a separate mechanism. Details and a recommended fix are in the epic comment.

## Not touched

Per child 16's do-not-touch list: `/ecs/pylot-workers` CloudWatch log-group references, the teams-api legacy-name strip (stays asymmetric), distill `META_SKILLS`, memory-eval fixtures, and specs/CHANGELOG history. No pylot-repo changes here at all.

## (e)

Final `pylot skills sync --org fellowship-dev` runs **post-merge, via the loop coordinator** — not from this PR.
