### PR TITLE
fix(cto-review): fail closed on merge authority

### DIFF
--- a/skills/ops/cto-review/SKILL.md
+++ b/skills/ops/cto-review/SKILL.md
@@ -33,7 +33,7 @@ Example: `/cto-review 742 fellowship-dev/booster-pack`.
 
 | Stage | Mode | Description |
 |-------|------|-------------|
-| 01-setup | subagent | Fetch repo context, PR metadata, full diff, merge state, **all PR comments + label snapshot** (#2918), **resolve the pipeline lane** (#2996, step 5.3). Short-circuit if CLOSED-not-merged or if an infra/backend PR lacks staging evidence. The staging gate is **waived on `lane:fast`** (#2996) — the lane classifier already proved the diff touches no deployable surface and test-in-staging deliberately never ran. Visual evidence (5.6) is evaluated the same way but is a **notice, not a short-circuit**. Both checks search the PR body first, then comments (newest-first), and both accept `N/A` within 3 lines of their heading as the waiver. |
+| 01-setup | subagent | Fetch repo context, PR metadata, full diff, merge state, **all PR comments + label snapshot** (#2918), **resolve the pipeline lane** (#2996, step 5.3), and resolve merge authority from the DB-authoritative team `deploy.release_mode`. Only explicit `ship` permits automated merge; every other state is label-only. Short-circuit if CLOSED-not-merged or if an infra/backend PR lacks staging evidence. The staging gate is **waived on `lane:fast`** (#2996) — the lane classifier already proved the diff touches no deployable surface and test-in-staging deliberately never ran. Visual evidence (5.6) is evaluated the same way but is a **notice, not a short-circuit**. Both checks search the PR body first, then comments (newest-first), and both accept `N/A` within 3 lines of their heading as the waiver. |
 | 02-review | subagent | **Judgement layer first** (#2918): read all labels + all comments, identify and classify every blocker (resolved/unresolved). Then ONE cohesive review of the whole diff across all dimensions → verdict + checklist + action items + **receipts block**. Review depth is identical in both lanes. |
 | 03-synthesize-act | inline | Post GH comment (always includes `## Checked / Found` receipts), apply label. **Step 3.0: owner gate** (#2918) — read labels fresh from GitHub; if `security` or `waiting-on-owner` present: post park comment, apply `waiting-on-owner`, emit `status=blocked`, STOP. **Step 3.1: lane merge bar** (#2996) — from the same fresh read: `lane:fast` requires `reviewed` only; everything else requires `reviewed` + `double-checked`. Otherwise: merge-or-label honoring merge state, write report file, emit outcome marker. |
 
@@ -205,6 +205,11 @@ Post the comment, apply the label, merge-or-label, write the report file, and em
 16. **The fast lane does not touch prod's gate (#2996)** — it skips the PRE-MERGE staging deploy,
     not the release train. `scripts/ci-release-gate.sh` still runs the unscoped full corpus before
     anything reaches production. A fast-lane merge is a merge to develop; prod is still gated.
+17. **Merge authority is explicit and DB-authoritative** — stage 01 MUST use
+    `resolve-merge-strategy.sh`, which reads live team configuration through the Pylot CLI. Only
+    `deploy.release_mode=ship` grants automated merge authority. `propose`, missing configuration,
+    lookup failure, malformed output, or an ambiguous repo-to-team mapping all resolve to
+    `label-only`. Never read a legacy `crew.yml`, and never default to auto-merge.
 
 ## Reference files
 

--- a/skills/ops/cto-review/resolve-merge-strategy.sh
+++ b/skills/ops/cto-review/resolve-merge-strategy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:?usage: resolve-merge-strategy.sh <org/repo>}"
+pylot_bin="${PYLOT_CLI_BIN:-pylot}"
+
+# Team configuration is DB-authoritative. Failure or ambiguity must remove merge
+# authority rather than silently restoring it.
+if ! teams_json="$("$pylot_bin" teams list 2>/dev/null)"; then
+  echo "label-only"
+  exit 0
+fi
+
+strategy="$({
+  printf '%s' "$teams_json" | jq -r --arg repo "$repo" '
+    [
+      .teams[]?
+      | select(any(.repos[]?; ascii_downcase == ($repo | ascii_downcase)))
+      | (.deploy.release_mode // "propose")
+    ]
+    | if length == 1 and .[0] == "ship" then "auto" else "label-only" end
+  '
+} 2>/dev/null || true)"
+
+# Exactly one explicit `ship` policy grants automated merge authority. Missing,
+# malformed, conflicting, or `propose` configuration is fail-closed.
+case "$strategy" in
+  auto) echo "auto" ;;
+  *) echo "label-only" ;;
+esac

--- a/skills/ops/cto-review/stages/01-setup/CONTEXT.md
+++ b/skills/ops/cto-review/stages/01-setup/CONTEXT.md
@@ -613,23 +613,18 @@ gh pr diff $PR --repo $REPO -- "**/package.json" "**/Gemfile" "**/requirements.t
 gh pr checks $PR --repo $REPO || echo "CHECKS_UNAVAILABLE"
 ```
 
-9. Resolve the team merge strategy (default `auto`):
+9. Resolve the team merge strategy from Pylot's DB-authoritative live team
+   configuration. Automated merge authority is explicit: only
+   `deploy.release_mode=ship` maps to `auto`; `propose`, missing, malformed,
+   ambiguous, or unavailable configuration maps to `label-only`:
 ```bash
-MERGE_STRATEGY=$(python3 -c "
-import yaml
-with open('$PYLOT_DIR/crew.yml') as f:
-    data = yaml.safe_load(f)
-for team, cfg in data.get('crew', {}).items():
-    if not isinstance(cfg, dict): continue
-    for r in cfg.get('repos', []):
-        if r.lower() == '$REPO'.lower():
-            print(cfg.get('merge_strategy', 'auto'))
-            exit()
-print('auto')
-" 2>/dev/null || echo "auto")
+MERGE_RESOLVER="skills/cto-review/resolve-merge-strategy.sh"
+test -f "$MERGE_RESOLVER" || MERGE_RESOLVER="skills/ops/cto-review/resolve-merge-strategy.sh"
+MERGE_STRATEGY=$(bash "$MERGE_RESOLVER" "$REPO")
 echo "merge_strategy=$MERGE_STRATEGY"
 ```
-(Crew config may live in the DB rather than a YAML file; if `crew.yml` is absent, default `auto`.)
+Do not read `crew.yml`: live Pylot team configuration is stored in the database.
+Do not infer merge authority from a missing file or from the model's judgement.
 
 10. Write handoff (capture the full diff verbatim — stage 02 reviews it from here).
 

--- a/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
+++ b/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
@@ -249,14 +249,14 @@ conflict is NOT a hold reason — finish it now, in this order:
 
 Use the `merge_strategy` resolved in stage 01:
 ```bash
-if [ "$MERGE_STRATEGY" = "label-only" ]; then
-  # Team requires human merge — label instead
+if [ "$MERGE_STRATEGY" = "auto" ]; then
+  # Exactly one live team explicitly selected deploy.release_mode=ship.
+  gh pr merge $PR --repo $REPO --merge
+else
+  # Every missing, malformed, ambiguous, or propose state requires human merge.
   gh label create "ready-to-merge" --repo $REPO --color "0e8a16" --description "Agent-verified, Max merges" 2>/dev/null || true
   gh pr edit $PR --repo $REPO --add-label "ready-to-merge"
-  echo "Labeled ready-to-merge (merge_strategy: label-only)"
-else
-  # Default: auto-merge
-  gh pr merge $PR --repo $REPO --merge
+  echo "Labeled ready-to-merge (merge_strategy: ${MERGE_STRATEGY:-missing}; automated merge requires exact auto)"
 fi
 ```
 If CI is failing: do NOT merge — the verdict should already be hold; note the CI failure in the

--- a/skills/ops/cto-review/test_resolve_merge_strategy.sh
+++ b/skills/ops/cto-review/test_resolve_merge_strategy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+resolver="$script_dir/resolve-merge-strategy.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "$tmp_dir/pylot" <<'SH'
+#!/usr/bin/env bash
+if [ "${PYLOT_TEST_FAIL:-}" = "1" ]; then exit 1; fi
+printf '%s' "${PYLOT_TEST_TEAMS:-{\"teams\":[]}}"
+SH
+chmod +x "$tmp_dir/pylot"
+
+assert_strategy() {
+  expected="$1"
+  payload="$2"
+  actual="$(PYLOT_CLI_BIN="$tmp_dir/pylot" PYLOT_TEST_TEAMS="$payload" "$resolver" Lexgo-cl/rails-backend)"
+  if [ "$actual" != "$expected" ]; then
+    echo "expected $expected, got $actual for $payload" >&2
+    exit 1
+  fi
+}
+
+assert_strategy auto '{"teams":[{"repos":["Lexgo-cl/rails-backend"],"deploy":{"release_mode":"ship"}}]}'
+assert_strategy auto '{"teams":[{"repos":["lexgo-cl/RAILS-BACKEND"],"deploy":{"release_mode":"ship"}}]}'
+assert_strategy label-only '{"teams":[{"repos":["Lexgo-cl/rails-backend"],"deploy":{"release_mode":"propose"}}]}'
+assert_strategy label-only '{"teams":[{"repos":["Lexgo-cl/rails-backend"],"deploy":null}]}'
+assert_strategy label-only '{"teams":[]}'
+assert_strategy label-only '{"teams":[{"repos":["Lexgo-cl/rails-backend"],"deploy":{"release_mode":"ship"}},{"repos":["Lexgo-cl/rails-backend"],"deploy":{"release_mode":"propose"}}]}'
+assert_strategy label-only '{"teams":[{"repos":["Lexgo-cl/rails-backend"],"deploy":{"release_mode":"ship"}},{"repos":["Lexgo-cl/rails-backend"],"deploy":{"release_mode":"ship"}}]}'
+assert_strategy label-only 'not-json'
+
+actual="$(PYLOT_CLI_BIN="$tmp_dir/pylot" PYLOT_TEST_FAIL=1 "$resolver" Lexgo-cl/rails-backend)"
+test "$actual" = "label-only"
+
+echo "resolve-merge-strategy: all cases passed"


### PR DESCRIPTION
## Problem

`cto-review` resolved merge authority from `$PYLOT_DIR/crew.yml`, even though Pylot team configuration is DB-authoritative. When that legacy file was absent, the skill explicitly defaulted to automatic merge.

That failure path affected every DB-only team. On Lexgo PR #1996 it allowed the Pylot App to merge into `develop` despite the intended label-only workflow.

## Fix

- Resolve the repository's live team through `pylot teams list`.
- Treat `deploy.release_mode` as the authoritative policy:
  - exactly one matching team with explicit `ship` → `auto`
  - `propose`, missing config, CLI failure, malformed output, or ambiguous team ownership → `label-only`
- Remove the legacy `crew.yml` lookup.
- Change the action stage so it merges only on exact `MERGE_STRATEGY=auto`; every other value labels `ready-to-merge`.
- Support both flattened installed-skill and source-tree resolver paths.

## Verification

- Bundled resolver suite covers explicit ship, propose, missing config, CLI failure, malformed JSON, case-insensitive repo matching, conflicting teams, and duplicate ship teams.
- Existing staging-evidence suite: green.
- Existing visual-evidence suite: green.
- Bash syntax and `git diff --check`: clean.
- Independent clean-context forward test confirmed:
  - duplicate `ship + ship` fails closed
  - empty/malformed/unexpected strategy values cannot merge
  - quoted CLI executable and both skill paths behave safely

## Rollout

Lexgo's live `devops.deploy.release_mode` is already set to `propose`. After this PR merges, sync the skill catalog before restoring Rails' `chad-* → cto-review` automation triggers.
