### PR TITLE
fix(review): bind review receipts to current PR head

### DIFF
--- a/skills/ops/cto-review/shared/review-comment-format.md
+++ b/skills/ops/cto-review/shared/review-comment-format.md
@@ -11,6 +11,7 @@ gh pr comment $PR --repo $REPO --body "$(cat <<'COMMENT_EOF'
 **Repo:** $REPO
 **PR:** [$REPO#$PR]($PR_URL) — $PR_TITLE
 **Branch:** `$HEAD_BRANCH` → `$BASE_BRANCH`
+**Head reviewed:** `$CURRENT_HEAD_SHA`
 **Labels:** $CURRENT_LABELS
 
 ---

--- a/skills/ops/cto-review/stages/01-setup/CONTEXT.md
+++ b/skills/ops/cto-review/stages/01-setup/CONTEXT.md
@@ -57,7 +57,8 @@ gh api "repos/$REPO/issues?state=open&per_page=10" --jq '.[].title'
 
 5. Fetch PR metadata:
 ```bash
-gh pr view $PR --repo $REPO --json number,title,body,headRefName,baseRefName,url,files,labels,author,additions,deletions,commits
+gh pr view $PR --repo $REPO --json number,title,body,headRefName,headRefOid,baseRefName,url,files,labels,author,additions,deletions,commits
+CURRENT_HEAD_SHA=$(gh pr view $PR --repo $REPO --json headRefOid --jq '.headRefOid')
 
 # Existing labels
 gh pr view $PR --repo $REPO --json labels --jq '.labels[].name'
@@ -642,6 +643,7 @@ Path: `.procedure-output/cto-review/01-setup/handoff.md`
 - URL: {url}
 - Author: {author}
 - Branch: `{headRefName}` -> `{baseRefName}`
+- Current HEAD SHA: {CURRENT_HEAD_SHA}
 - Labels: {comma-separated current labels}
 - Additions/Deletions: +{N} / -{N}
 

--- a/skills/ops/cto-review/stages/02-review/CONTEXT.md
+++ b/skills/ops/cto-review/stages/02-review/CONTEXT.md
@@ -33,6 +33,10 @@ ledger shows what they caught and what status each finding is in. Trust what the
   production-impact judgement on HIGH-tier PRs
 - `## Review State: none` (pre-#2210 PR) → fall back to the old assumption that code quality was
   covered by the earlier phases, and note that in your output
+- compare its `head_sha` with `Current HEAD SHA` from PR Identity. If they differ, the manifest is
+  historical evidence only: preserve finding IDs/status history, but do not trust it as coverage
+  of current HEAD. Review the complete current diff at normal depth and continue; do not reject or
+  restart the pipeline solely because the earlier receipt is stale.
 
 Focus on: docs gaps, ops holes, downstream risk, security, and merge strategy — reading the WHOLE
 diff in one pass.

--- a/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
+++ b/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
@@ -38,6 +38,7 @@ mandatory for every verdict comment, not optional (#2918).
 ```bash
 gh pr comment $PR --repo $REPO --body "$(cat <<'COMMENT_EOF'
 # CTO Review: $REPO PR #$PR — $PR_TITLE
+**Head reviewed:** `{CURRENT_HEAD_SHA from stage 01}`
 ... (see shared/review-comment-format.md — verbatim) ...
 
 ## Checked / Found
@@ -83,6 +84,7 @@ Step 3.
 
 **Finalizing `REVIEW_STATE_JSON` (#2210):** take the incoming state from the setup handoff's
 `## Review State` (or a fresh `{"v":1,"findings":[]}` if `none`), set `"stage": "cto-review"`,
+set `"head_sha"` to the stage-01 `Current HEAD SHA` (never preserve a stale upstream SHA),
 update finding statuses per stage 02's Ledger Reconciliation (a REWORK verdict leaves its driving
 findings `open`; LGTM with dismissals records the dismissal reasons in `note`), and append
 `verified` entries for the dimensions this review covered. Validate with `jq .` before posting —

--- a/skills/ops/double-check/SKILL.md
+++ b/skills/ops/double-check/SKILL.md
@@ -35,7 +35,7 @@ shim mint short-lived App installation tokens per operation, so git URLs must st
 
 | Stage | Mode | Description |
 |-------|------|-------------|
-| 01-setup | subagent | Fetch PR metadata, CI status, existing review comments, full diff; checkout PR branch + merge base |
+| 01-setup | subagent | Fetch PR metadata including current HEAD, classify the incoming review receipt as current/stale/absent, capture comments + full diff, and checkout PR branch + merge base |
 | 02-review | subagent | ONE cohesive critical review in clean context: reconcile the PR's claims against the diff, verify first review's claims, find missed edge cases, check tests/docs → consolidated verdict + curated findings |
 | 03-fix | subagent | Apply MUST-FIX (and worthwhile NICE-TO-HAVE) fixes, re-run tests, push — only if fixes are needed |
 | 04-post | inline | Re-check the claims gate against the live PR, detect re-check context (needs-work in labels), post curated review comment, apply labels to close the pipeline loop (re-check) or signal completion (first-check), verify the side effects landed, write local report file, emit outcome marker |
@@ -154,6 +154,10 @@ from the orchestrator (never from a subagent).
     `review-state v1` block; stage 02 curates by ledger ID at tier-scaled depth (escalate-only);
     stage 04 re-posts the updated block as valid JSON. No block found → pre-#2210 fallback
     (verbatim first-review curation, full depth).
+13. **A stale first review is historical evidence, not a blocker or current coverage** — compare
+    its `head_sha` with the post-rebase PR HEAD. Continue the cohesive review against the complete
+    current diff, re-check prior findings, and post a new current-head receipt. Never restart the
+    whole pipeline merely because the incoming receipt is stale.
 
 ## Reference files
 

--- a/skills/ops/double-check/stages/01-setup/CONTEXT.md
+++ b/skills/ops/double-check/stages/01-setup/CONTEXT.md
@@ -30,6 +30,7 @@ PR_TITLE=$(gh pr view $PR --repo $REPO --json title --jq '.title')
 PR_BRANCH=$(gh pr view $PR --repo $REPO --json headRefName --jq '.headRefName')
 BASE_BRANCH=$(gh pr view $PR --repo $REPO --json baseRefName --jq '.baseRefName')
 PR_URL=$(gh pr view $PR --repo $REPO --json url --jq '.url')
+INITIAL_HEAD_SHA=$(gh pr view $PR --repo $REPO --json headRefOid --jq '.headRefOid')
 ```
 
 ### Check CI status (best-effort — may fail with PAT)
@@ -115,6 +116,16 @@ if [ -z "$REBASE_FAILED" ]; then
   git push origin $PR_BRANCH --force-with-lease
   echo "Rebased $PR_BRANCH onto origin/$BASE_BRANCH and pushed — PR conflict cleared"
 fi
+
+CURRENT_HEAD_SHA=$(git rev-parse HEAD)
+REVIEW_HEAD_SHA=$(echo "$REVIEW_STATE" | jq -r '.head_sha // empty' 2>/dev/null || true)
+if [ -z "$REVIEW_HEAD_SHA" ]; then
+  REVIEW_RECEIPT_STATUS="absent"
+elif [ "$REVIEW_HEAD_SHA" = "$CURRENT_HEAD_SHA" ]; then
+  REVIEW_RECEIPT_STATUS="current"
+else
+  REVIEW_RECEIPT_STATUS="stale"
+fi
 ```
 
 If the rebase cannot be auto-resolved (or the PR can't be fetched/checked out), write the
@@ -137,6 +148,8 @@ setup_ok: {true|false}
 - Author: {author}
 - Size: +{additions} / -{deletions}, {N} files, {N} commits
 - Labels: {labels or none}
+- Initial HEAD SHA: {INITIAL_HEAD_SHA}
+- Current HEAD SHA: {CURRENT_HEAD_SHA after any rebase}
 
 ## Local Checkout
 - REPO_DIR: {REPO_DIR}
@@ -152,6 +165,11 @@ diff. Never summarise, trim, or paraphrase it.}
 
 ## Review State
 {the LAST review-state v1 JSON verbatim — or "none" (pre-#2210 PR or unparseable block)}
+- Receipt status: {current | stale | absent}
+- Receipt head SHA: {REVIEW_HEAD_SHA or none}
+
+`stale` is not a setup failure and does not restart the pipeline. It tells stage 02 not to treat
+the old verification manifest as coverage of current HEAD.
 
 ## First Review (existing comments + reviews, verbatim)
 {every finding from CI / bots / reviewers, verbatim — or "No existing review comments found".
@@ -170,6 +188,7 @@ repeated verbatim.}
 ## Success criteria
 - `setup_ok: true`
 - PR metadata, CI status, first review (verbatim), changed files, and full diff all captured
+- Current post-rebase HEAD and incoming receipt freshness recorded
 - PR body captured untruncated; changed-file manifest carries per-file line counts
 - Any diff truncation flagged explicitly (never silent)
 - PR branch checked out in REPO_DIR, rebased onto base, and pushed; REPO_DIR recorded for downstream stages

--- a/skills/ops/double-check/stages/02-review/CONTEXT.md
+++ b/skills/ops/double-check/stages/02-review/CONTEXT.md
@@ -31,6 +31,11 @@ All four are judged together as cross-cutting concerns, yielding ONE verdict.
    verification manifest from review-pr, #2210). Build a mental model of what the diff changes and
    why — the ledger's summary spares you re-deriving intent, but the DIFF remains the ground truth.
 
+   If `Receipt status: stale`, retain its finding IDs and history, but do not trust its `verified`
+   manifest as coverage of current HEAD. Re-check every still-relevant finding against the current
+   full diff and perform the normal tier-scaled cohesive review. Staleness never forces a pipeline
+   restart and never suppresses this stage.
+
 2. **Reconcile claims vs diff — BLOCKING, do this before curating anything.**
    Extract every *concrete, checkable* claim from the PR title and body: named files/modules,
    endpoints or routes, functions, migrations, config keys, test files and test counts,
@@ -140,6 +145,7 @@ here in one line — this text is what a human reads first.}
 
 ## Risk Tier
 - tier: {from Review State, or the ESCALATED tier + reason, or "unknown (no review-state)"}
+- incoming_receipt: {current | stale | absent}; reviewed_head={sha|none}; current_head={sha}
 
 ## Curated First-Review Findings
 | ID | Finding | Verdict | Action |

--- a/skills/ops/double-check/stages/04-post/CONTEXT.md
+++ b/skills/ops/double-check/stages/04-post/CONTEXT.md
@@ -60,7 +60,9 @@ gh pr view $PR --repo $REPO --json title,body,additions,deletions,files,headRefO
   > /tmp/dc-pr-$PR.json
 LIVE_STAT=$(jq -r '"+\(.additions)/-\(.deletions), \(.files|length) files"' /tmp/dc-pr-$PR.json)
 LIVE_FILES=$(jq -r '.files[].path' /tmp/dc-pr-$PR.json)
+LIVE_HEAD_SHA=$(jq -r '.headRefOid' /tmp/dc-pr-$PR.json)
 echo "[stage-04] live diff: $LIVE_STAT"
+echo "[stage-04] head reviewed: $LIVE_HEAD_SHA"
 printf '%s\n' "$LIVE_FILES"
 ```
 
@@ -90,6 +92,7 @@ gh pr comment $PR --repo $REPO --body "$(cat <<'REVIEW_EOF'
 
 **Reviewer:** Automated double-check
 **Branch:** `$PR_BRANCH` → `$BASE_BRANCH`
+**Head reviewed:** `$LIVE_HEAD_SHA`
 
 ---
 
@@ -139,7 +142,8 @@ REVIEW_EOF
 
 **Updating `REVIEW_STATE_JSON` (#2210):** take the incoming state from the setup handoff's
 `## Review State` (or start a fresh object with `"findings": []` if it was `none`), then:
-- set `"stage": "double-check"` and refresh `"head_sha"` (fix commits may have moved it)
+- set `"stage": "double-check"` and set `"head_sha"` to `LIVE_HEAD_SHA` (never copy the stale
+  incoming value; fix commits or rebases may have moved it)
 - set `"tier"` to the final tier (respect any escalation from stage 02; never lower)
 - update each existing finding's `"status"`: `fixed` (stage 03 addressed it — add
   `"note": "fixed in <sha>"`), `dismissed` (DISCARD verdict — note the reason), or leave `open`

--- a/skills/ops/double-check/stages/04-post/CONTEXT.md
+++ b/skills/ops/double-check/stages/04-post/CONTEXT.md
@@ -47,6 +47,15 @@ fi
 VERDICT=$(grep "^verdict:" "$REVIEW_HANDOFF" | head -1 | awk '{print $2}')
 CLAIMS=$(grep "^claims_reconciled:" "$REVIEW_HANDOFF" | head -1 | awk '{print $2}')
 [ -n "$CLAIMS" ] || CLAIMS=unknown
+
+# Stage 02 records the exact checkout whose complete diff it reviewed. Treat a missing or
+# malformed value as unsafe rather than falling back to setup or the live PR.
+REVIEWED_HEAD_SHA=$(sed -n 's/.*; current_head=\([0-9a-f]\{40\}\)$/\1/p' "$REVIEW_HANDOFF" | head -1)
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+  echo "[stage-04] refusing to post: stage 02 did not record an exact reviewed HEAD SHA"
+  echo "[pylot] outcome=\"double-check failed at stage 04: reviewed HEAD SHA missing\" status=failed"
+  exit 1
+fi
 ```
 
 ### Claims-vs-diff gate against the LIVE PR (BLOCKING — run before posting)
@@ -62,8 +71,18 @@ LIVE_STAT=$(jq -r '"+\(.additions)/-\(.deletions), \(.files|length) files"' /tmp
 LIVE_FILES=$(jq -r '.files[].path' /tmp/dc-pr-$PR.json)
 LIVE_HEAD_SHA=$(jq -r '.headRefOid' /tmp/dc-pr-$PR.json)
 echo "[stage-04] live diff: $LIVE_STAT"
-echo "[stage-04] head reviewed: $LIVE_HEAD_SHA"
+echo "[stage-04] stage-02 head reviewed: $REVIEWED_HEAD_SHA"
+echo "[stage-04] live head: $LIVE_HEAD_SHA"
 printf '%s\n' "$LIVE_FILES"
+
+# A file-name or aggregate-stat comparison cannot prove content identity. This equality is the
+# receipt boundary: stage 04 may certify only the exact commit whose complete diff stage 02 read.
+if [ "$LIVE_HEAD_SHA" != "$REVIEWED_HEAD_SHA" ]; then
+  echo "[stage-04] refusing to post: PR HEAD moved after review ($REVIEWED_HEAD_SHA -> $LIVE_HEAD_SHA)"
+  echo "[stage-04] run double-check again so stage 02 reviews the complete diff at the new HEAD"
+  echo "[pylot] outcome=\"double-check failed at stage 04: PR HEAD moved after review\" status=failed"
+  exit 1
+fi
 ```
 
 Then:
@@ -72,8 +91,8 @@ Then:
   read the live `.body` and `.files` from `/tmp/dc-pr-$PR.json` and apply the stage-02 rules
   (backed / elsewhere / unbacked). Set `CLAIMS=pass` or `CLAIMS=fail` from what you find.
 - **`CLAIMS=pass`** — sanity-check that the live changed-file list still matches the manifest
-  stage 02 reviewed. If files were added or removed since setup (the branch moved, or stage 03
-  pushed), re-reconcile the affected claims before continuing.
+  stage 02 reviewed. SHA equality above is mandatory even when the file list is unchanged; a
+  stage-03 fix or any other push requires a fresh stage-02 complete-diff review before posting.
 - **`CLAIMS=fail`** — force `VERDICT=needs-work` and take **Branch D** below. Do not apply
   `double-checked`, whatever stage 02's verdict said.
 
@@ -164,6 +183,11 @@ Validate with `jq .` before posting — downstream cto-review parses it.
 
 Also append to the `verified` manifest:
 `{"what": "PR title/body claims reconciled against live changed files", "how": "gh pr view", "by": "double-check"}`
+
+Before posting, verify the post-review-push invariant explicitly: if a push changes content only
+inside files already present in stage 02's manifest, its new `LIVE_HEAD_SHA` still differs from
+`REVIEWED_HEAD_SHA`, the equality guard exits non-zero, and no review comment, receipt, or label
+operation is reached. Unchanged filenames and stats never relax this invariant.
 
 ### Apply labels (re-check vs first-check)
 

--- a/skills/ops/review-pr/SKILL.md
+++ b/skills/ops/review-pr/SKILL.md
@@ -43,7 +43,7 @@ Parse from `$ARGUMENTS`: `PR=$1`, `REPO=$2`. Both required.
 
 | Stage | Mode | Description |
 |-------|------|-------------|
-| 00-context | inline | Dedup gate (exit if already `reviewed`) + gather PR metadata, conventions, existing comments, CI status, the full diff, the **mechanical risk tier** (#2210), and **new auth surface detection** (#2918) |
+| 00-context | inline | Head-aware dedup gate (exit only when `reviewed` has a valid receipt for current HEAD) + gather PR metadata, conventions, existing comments, CI status, the full diff, the **mechanical risk tier** (#2210), and **new auth surface detection** (#2918) |
 | 01-cohesive-review | subagent | **Critical-judgement step.** ONE subagent reviews the whole diff in cohesion at tier-scaled depth (LOW bounded / MEDIUM full / HIGH full + runtime-shape checklist): analyze, confidence-score findings (≥80), **security-classify each finding** (#2918), convention compliance, Closes-vs-Refs. Clean isolated context. |
 | 02-post | inline | Post structured review comment **with the embedded `review-state v1` block** + **apply `security` label if auth-surface or security-class findings** (#2918) + **apply the deterministic `lane:fast`/`lane:staging` label** (#2996) + apply `reviewed` label **LAST** + write local report + emit outcome marker |
 
@@ -67,9 +67,10 @@ Run stage 00 yourself (orchestrator context). Read CONTEXT.md:
 ```
 skills/review-pr/stages/00-context/CONTEXT.md
 ```
-Run the dedup gate first. If the PR already has the `reviewed` label, emit the already-complete
-outcome marker and STOP — do not spawn stage 01. Otherwise gather all context + the full diff and
-write the handoff to `.procedure-output/review-pr/00-context/handoff.md`.
+Run the dedup gate first. Short-circuit only when the PR has `reviewed` AND the latest valid
+`review-state v1` block has `head_sha` equal to the current `headRefOid`. A missing, invalid, or
+stale receipt is not completion: record `review_run: stale-refresh`, continue through the normal
+review, and let stage 02 re-toggle `reviewed` after posting the current-head receipt.
 
 ### Stage 01 (single subagent — NO fan-out)
 
@@ -122,7 +123,7 @@ Post the comment, apply the `security` label if warranted (Step 2), apply the `l
 
 ## Exit paths
 
-- **Already complete**: stage 00 dedup gate hits → `[pylot] outcome="already complete — reviewed label already applied" status=success` (orchestrator, inline)
+- **Already complete**: stage 00 dedup gate finds a current-head receipt → `[pylot] outcome="already complete — reviewed receipt matches current HEAD {sha}" status=success` (orchestrator, inline)
 - **Success**: stage 02 emits `[pylot] outcome="review-pr complete — reviewed label applied, lane:{fast|staging|n/a}" status=success`
 - **Failure**: failing stage emits `[pylot] outcome="review-pr failed at stage NN: {reason}" status=failed`
 
@@ -142,7 +143,9 @@ Post the comment, apply the `security` label if warranted (Step 2), apply the `l
    `127.0.0.1:4242`. Operators surface the report via the mission report.
 10. **Never apply `double-checked`** — only `reviewed`. The verdict is always "proceed to
     double-check"; this skill never blocks.
-11. **Do not skip stages** — every stage executes (except stage 01/02 when the dedup gate exits at 00).
+11. **Do not skip stages** — every stage executes (except stage 01/02 when the head-aware dedup
+    gate proves the latest receipt matches current HEAD). A `reviewed` label by itself is never
+    proof of completion.
 12. **Risk tier is mechanical and escalate-only** (#2210) — stage 00 computes it from the rubric;
     stage 01 may raise it (recording why) but never lower it. LOW-tier review is bounded by design —
     do not "be thorough" past the tier; the saved depth is reallocated to HIGH-tier PRs.
@@ -162,6 +165,10 @@ Post the comment, apply the `security` label if warranted (Step 2), apply the `l
     automations that react to `reviewed` read the label set carried in that webhook payload, so a
     lane label applied after `reviewed` is invisible to them and the PR silently pays for the full
     pipeline. This ordering is the mechanism, not a style preference.
+17. **Review completion is head-bound** — every posted review names and records the automatically
+    fetched current HEAD SHA. When refreshing a stale receipt, remove and re-add `reviewed` only
+    after the new comment and prerequisite labels land, so downstream stages receive a current
+    trigger without restarting or blocking the review itself.
 
 ## Reference files
 

--- a/skills/ops/review-pr/stages/00-context/CONTEXT.md
+++ b/skills/ops/review-pr/stages/00-context/CONTEXT.md
@@ -10,8 +10,9 @@ Run the dedup gate, then gather all PR context and the full diff that the review
 need. This stage runs inline in the orchestrator — do NOT spawn a Task. Read-only: no checkout, no
 fixes, no pushes.
 
-If the dedup gate trips (PR already has the `reviewed` label), the orchestrator emits the
-already-complete outcome marker and STOPS — stages 01 and 02 do not run.
+If the dedup gate proves that the latest valid review receipt matches current HEAD, the
+orchestrator emits the already-complete outcome marker and STOPS. A label without a matching
+receipt is stale evidence and continues through the pipeline.
 
 ## Steps
 
@@ -21,10 +22,23 @@ already-complete outcome marker and STOPS — stages 01 and 02 do not run.
 export PR=$1
 export REPO=$2
 
-ALREADY_DONE=$(gh pr view $PR --repo $REPO --json labels --jq '[.labels[].name] | contains(["reviewed"])')
-if [ "$ALREADY_DONE" = "true" ]; then
-  echo "[pylot] outcome=\"already complete — reviewed label already applied\" status=success"
+PR_SNAPSHOT=$(gh pr view $PR --repo $REPO --json headRefOid,labels,comments)
+HEAD_SHA=$(printf '%s' "$PR_SNAPSHOT" | jq -r '.headRefOid')
+HAS_REVIEWED=$(printf '%s' "$PR_SNAPSHOT" | jq '[.labels[].name] | contains(["reviewed"])')
+REVIEW_STATE=$(printf '%s' "$PR_SNAPSHOT" | jq -r '.comments[].body' \
+  | awk '/^<!-- review-state v1$/{buf="";f=1;next} f&&/^-->$/{f=0;last=buf;next} f{buf=buf $0 "\n"} END{printf "%s", last}')
+printf '%s' "$REVIEW_STATE" | jq . >/dev/null 2>&1 || REVIEW_STATE=""
+REVIEWED_SHA=$(printf '%s' "$REVIEW_STATE" | jq -r '.head_sha // empty' 2>/dev/null || true)
+
+if [ "$HAS_REVIEWED" = "true" ] && [ -n "$REVIEWED_SHA" ] && [ "$REVIEWED_SHA" = "$HEAD_SHA" ]; then
+  echo "[pylot] outcome=\"already complete — reviewed receipt matches current HEAD $HEAD_SHA\" status=success"
   exit 0
+fi
+
+REVIEW_RUN="fresh"
+if [ "$HAS_REVIEWED" = "true" ]; then
+  REVIEW_RUN="stale-refresh"
+  echo "[review-pr] stale reviewed evidence: receipt=${REVIEWED_SHA:-missing} current=$HEAD_SHA — continuing"
 fi
 ```
 
@@ -65,8 +79,7 @@ gh pr diff $PR --repo $REPO
 # Changed file names (for quick overview)
 gh pr diff $PR --repo $REPO --name-only
 
-# Head SHA (recorded in review-state so later stages know which snapshot was reviewed)
-HEAD_SHA=$(gh pr view $PR --repo $REPO --json headRefOid --jq '.headRefOid')
+# HEAD_SHA was fetched atomically with labels/comments in the dedup snapshot above.
 ```
 
 Capture the FULL diff into the handoff — the entire diff is reviewed together in stage 01, so the
@@ -160,6 +173,8 @@ Path: `.procedure-output/review-pr/00-context/handoff.md`
 - Size: +{ADDITIONS} / -{DELETIONS} across {FILE_COUNT} files
 - Labels: {labels}
 - auth_surface: {none|new-auth-surface}
+- review_run: {fresh|stale-refresh}
+- prior_review_head_sha: {REVIEWED_SHA or none}
 
 ## PR Body
 {full PR body}
@@ -187,7 +202,7 @@ Path: `.procedure-output/review-pr/00-context/handoff.md`
 ```
 
 ## Success criteria
-- Dedup gate ran first; if `reviewed` already present, procedure stopped here
+- Head-aware dedup gate ran first; procedure stopped only for a valid current-head receipt
 - PR metadata, body, conventions, existing comments, CI status all captured
 - The FULL diff captured in the handoff (not truncated)
 - Auth surface detection ran; `auth_surface` recorded in handoff

--- a/skills/ops/review-pr/stages/02-post/CONTEXT.md
+++ b/skills/ops/review-pr/stages/02-post/CONTEXT.md
@@ -26,6 +26,7 @@ gh pr comment $PR --repo $REPO --body "$(cat <<'REVIEW_EOF'
 ## PR Review: $REPO#$PR — $PR_TITLE
 
 **Branch:** `$PR_BRANCH` → `$BASE_BRANCH`
+**Head reviewed:** `$HEAD_SHA`
 **Size:** +$ADDITIONS / -$DELETIONS across $FILE_COUNT files
 
 ### Summary
@@ -229,6 +230,10 @@ fi
 Only AFTER the comment posts successfully **and** after Steps 2 and 2.5 have applied their labels.
 
 ```bash
+REVIEW_RUN=$(grep -m1 'review_run:' .procedure-output/review-pr/00-context/handoff.md | awk '{print $3}' || echo "fresh")
+if [ "$REVIEW_RUN" = "stale-refresh" ]; then
+  gh pr edit $PR --repo $REPO --remove-label "reviewed" 2>/dev/null || true
+fi
 gh label create "reviewed" --repo $REPO --color "bfd4f2" --description "First-pass review complete" 2>/dev/null || true
 gh pr edit $PR --repo $REPO --add-label "reviewed"
 ```
@@ -243,6 +248,10 @@ the PR:
 | no lane label + `reviewed` | `review-pr-on-reviewed` | pre-#2996 behaviour (fail-closed default) |
 
 Never apply `double-checked` — that's a different skill entirely.
+
+On `stale-refresh`, removing then re-adding `reviewed` is intentional: the new receipt now binds
+the review to current HEAD, and the re-add emits the downstream event. Do not remove the label
+earlier; a failed comment or prerequisite-label step must leave the previous pipeline state intact.
 
 ### Step 4: Write Report (local file only — NO Quest)
 


### PR DESCRIPTION
## Summary

- make `review-pr` short-circuit only when the latest valid receipt matches current PR HEAD
- treat stale receipts as historical evidence in `double-check` and `cto-review`, continuing against the complete current diff instead of restarting or trusting stale coverage
- print the reviewed SHA in review comments and refresh `review-state v1.head_sha` at every stage
- re-toggle `reviewed` only after a stale refresh posts its current-head receipt and prerequisite labels

## Evidence

- reproduced against fellowship-dev/pylot#3156: receipt `fe57891b` vs current HEAD `2d2c67f` resolves to `stale-refresh`
- fixed a shell portability defect found during forward validation by using `printf` instead of `echo` for JSON/comment snapshots
- frontmatter parsed for all three skills
- Markdown fence parity passed for all affected skill files
- `git diff --check` passed

## Notes

The generic Codex `quick_validate.py` rejects the repository's existing `user-invocable` frontmatter extension, so validation used the repository's accepted schema instead.
