### PR TITLE
fix(cto-review): fail closed CI evidence for no-check repos

### DIFF
--- a/skills/ops/cto-review/CONTEXT.md
+++ b/skills/ops/cto-review/CONTEXT.md
@@ -39,7 +39,9 @@ over here.
 - Evidence checks fire only on OPEN PRs. Staging is the only one that can block; visual is always
   a notice. Both waive generously — a diff that does not hit the check's paths never reaches its
   body scan — and both accept `N/A` within 3 lines of their heading as the machine-parsed waiver.
-- Never merge if CI is red, even on LGTM.
+- CI is classified once at the reviewed head as pass, block, or N/A. N/A means no configured
+  checks, not green CI, and never bypasses the normal review, lane, owner-gate, or merge-authority
+  requirements; block never merges.
 - Reporting is the local report file only. No Quest.
 
 ## Folder map

--- a/skills/ops/cto-review/SKILL.md
+++ b/skills/ops/cto-review/SKILL.md
@@ -170,7 +170,9 @@ Post the comment, apply the label, merge-or-label, write the report file, and em
 6. **Each stage writes handoff.md before the next stage reads it.**
 7. **Do not skip stages** — every stage executes, except stage 02 is skipped only on the CLOSED-no-merge short-circuit.
 8. **Honor merge state** — never merge a CLOSED PR; for an already-merged PR, post the review as a post-merge note and never attempt merge.
-9. **Never merge if CI is red** — even on an LGTM verdict.
+9. **Never merge on a CI block** — Stage 01 classifies CI once as `pass`, `block`, or
+   `na-no-configured-checks`. Only pass or N/A may satisfy the CI prerequisite; N/A still requires
+   the normal review, lane, owner-gate, and merge-authority requirements.
 10. **No Quest** — reporting is the local report file only.
 11. **The staging gate fires first and is the only evidence short-circuit** (step 5.5). On that
     short-circuit, skip everything else and post its rejection inline. It cannot be bypassed by

--- a/skills/ops/cto-review/shared/review-comment-format.md
+++ b/skills/ops/cto-review/shared/review-comment-format.md
@@ -47,6 +47,7 @@ gh pr comment $PR --repo $REPO --body "$(cat <<'COMMENT_EOF'
 | Related code searched | [✅ evidence found / ❌ no evidence / N/A] |
 | Docs updated | [✅ / ❌ what is missing] |
 | Merge strategy | [Direct merge / Release train — reason] |
+| CI classification | [CI pass / CI: N/A — no configured checks / CI block — reason] |
 | FlowChad flows affected | [✅ none / ⚠️ re-run flowchad-runner post-merge / N/A] |
 | Production impact assessed | [✅ low risk / ⚠️ requires careful deploy / N/A] |
 

--- a/skills/ops/cto-review/stages/01-setup/CONTEXT.md
+++ b/skills/ops/cto-review/stages/01-setup/CONTEXT.md
@@ -619,74 +619,10 @@ gh pr diff $PR --repo $REPO -- "**/package.json" "**/Gemfile" "**/requirements.t
 CI_DIR="skills/cto-review/stages/01-setup"
 test -f "$CI_DIR/ci_gate.py" || CI_DIR="skills/ops/cto-review/stages/01-setup"
 
-# Check-runs response for the exact reviewed SHA. Preserve API failure separately from zero runs.
-CHECK_RUNS=$(gh api "repos/$REPO/commits/$CURRENT_HEAD_SHA/check-runs?per_page=100" 2>/dev/null) || CHECK_RUNS_OK=false
-: "${CHECK_RUNS_OK:=true}"
-
-# Legacy commit-status contexts are distinct from check-runs. Required contexts may be supplied by
-# either API, so omitting this response would falsely block a green external status or waive it.
-COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$CURRENT_HEAD_SHA/status" 2>/dev/null) || COMMIT_STATUSES_OK=false
-: "${COMMIT_STATUSES_OK:=true}"
-
-# A 404 means no branch protection is configured; every other failure remains a block.
-REQUIRED=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/tmp/cto-required.err) || REQUIRED_STATUS=$?
-if grep -q '404' /tmp/cto-required.err; then
-  REQUIRED='{"contexts":[]}'
-  REQUIRED_OK=true
-elif [ "${REQUIRED_STATUS:-0}" = "0" ]; then
-  REQUIRED_OK=true
-else
-  REQUIRED_OK=false
-fi
-
-# Rulesets can add required checks independently of legacy branch protection. A 404 means no
-# matching ruleset; any other error is evidence we cannot safely classify as N/A.
-RULESETS=$(gh api "repos/$REPO/rules/branches/$BASE_BRANCH" 2>/tmp/cto-rulesets.err) || RULESETS_STATUS=$?
-if grep -q '404' /tmp/cto-rulesets.err; then
-  RULESETS='[]'
-elif [ "${RULESETS_STATUS:-0}" != "0" ]; then
-  REQUIRED_OK=false
-fi
-
-# Enumerate workflow files at the PR head. Parse every declaration; a lookup or parsing failure
-# blocks rather than incorrectly waiving CI. `pr_workflows` holds PR-triggered workflows only.
-WORKFLOW_TREE=$(gh api "repos/$REPO/git/trees/$CURRENT_HEAD_SHA?recursive=1" 2>/dev/null) || WORKFLOW_TREE_OK=false
-: "${WORKFLOW_TREE_OK:=true}"
-PR_WORKFLOWS='[]'
-if [ "$WORKFLOW_TREE_OK" = true ]; then
-  WORKFLOW_PATHS=$(echo "$WORKFLOW_TREE" | python3 -c '
-import json, sys
-payload = json.load(sys.stdin)
-if payload.get("truncated") is True or not isinstance(payload.get("tree"), list):
-    sys.exit(1)
-for item in payload["tree"]:
-    if not isinstance(item, dict):
-        sys.exit(1)
-    path = item.get("path", "")
-    if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml")):
-        print(path)
-') || WORKFLOW_TREE_OK=false
-fi
-if [ "$WORKFLOW_TREE_OK" = true ]; then
-  PR_WORKFLOWS=$(printf '%s\n' "$WORKFLOW_PATHS" | while IFS= read -r path; do
-    content=$(gh api "repos/$REPO/contents/$path?ref=$CURRENT_HEAD_SHA" --jq .content 2>/dev/null | base64 -d) || exit 1
-    if printf '%s\n' "$content" | python3 -c '
-import re, sys
-text = sys.stdin.read()
-trigger = re.compile(r"^[ \\t]*(pull_request|pull_request_target|[\\\"\\x27](pull_request|pull_request_target)[\\\"\\x27])[ \\t]*:", re.M)
-inline = re.compile(r"^[ \\t]*on[ \\t]*:[^#\\n]*(pull_request|pull_request_target)", re.M)
-sys.exit(0 if trigger.search(text) or inline.search(text) else 1)
-'; then printf '%s\n' "$path"; fi
-  done | jq -Rsc 'split("\n") | map(select(length > 0))') || WORKFLOW_TREE_OK=false
-fi
-
-CI_EVIDENCE=$(jq -n \
-  --argjson runs "${CHECK_RUNS:-null}" \
-  --argjson statuses "${COMMIT_STATUSES:-null}" \
-  --argjson required "${REQUIRED:-null}" \
-  --argjson rulesets "${RULESETS:-null}" --argjson workflows "${PR_WORKFLOWS:-null}" \
-  --arg check_ok "$CHECK_RUNS_OK" --arg status_ok "$COMMIT_STATUSES_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
-  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]?]), pr_workflows: $workflows}')
+# This collector is the single evidence source for both reviewed-head and merge-time
+# classification. It paginates check-runs and legacy statuses, fails closed on incomplete
+# responses, and recognizes mapping, inline, and block-list pull-request workflow triggers.
+CI_EVIDENCE=$(bash "$CI_DIR/collect_ci_evidence.sh" "$REPO" "$CURRENT_HEAD_SHA" "$BASE_BRANCH")
 CI_RESULT=$(printf '%s' "$CI_EVIDENCE" | python3 "$CI_DIR/ci_gate.py")
 CI_CLASSIFICATION=$(echo "$CI_RESULT" | jq -r .classification)
 CI_REASON=$(echo "$CI_RESULT" | jq -r .reason)

--- a/skills/ops/cto-review/stages/01-setup/CONTEXT.md
+++ b/skills/ops/cto-review/stages/01-setup/CONTEXT.md
@@ -623,6 +623,11 @@ test -f "$CI_DIR/ci_gate.py" || CI_DIR="skills/ops/cto-review/stages/01-setup"
 CHECK_RUNS=$(gh api "repos/$REPO/commits/$CURRENT_HEAD_SHA/check-runs?per_page=100" 2>/dev/null) || CHECK_RUNS_OK=false
 : "${CHECK_RUNS_OK:=true}"
 
+# Legacy commit-status contexts are distinct from check-runs. Required contexts may be supplied by
+# either API, so omitting this response would falsely block a green external status or waive it.
+COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$CURRENT_HEAD_SHA/status" 2>/dev/null) || COMMIT_STATUSES_OK=false
+: "${COMMIT_STATUSES_OK:=true}"
+
 # A 404 means no branch protection is configured; every other failure remains a block.
 REQUIRED=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/tmp/cto-required.err) || REQUIRED_STATUS=$?
 if grep -q '404' /tmp/cto-required.err; then
@@ -649,13 +654,21 @@ WORKFLOW_TREE=$(gh api "repos/$REPO/git/trees/$CURRENT_HEAD_SHA?recursive=1" 2>/
 : "${WORKFLOW_TREE_OK:=true}"
 PR_WORKFLOWS='[]'
 if [ "$WORKFLOW_TREE_OK" = true ]; then
-  PR_WORKFLOWS=$(echo "$WORKFLOW_TREE" | python3 -c '
+  WORKFLOW_PATHS=$(echo "$WORKFLOW_TREE" | python3 -c '
 import json, sys
-for item in json.load(sys.stdin).get("tree", []):
+payload = json.load(sys.stdin)
+if payload.get("truncated") is True or not isinstance(payload.get("tree"), list):
+    sys.exit(1)
+for item in payload["tree"]:
+    if not isinstance(item, dict):
+        sys.exit(1)
     path = item.get("path", "")
     if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml")):
         print(path)
-' | while IFS= read -r path; do
+') || WORKFLOW_TREE_OK=false
+fi
+if [ "$WORKFLOW_TREE_OK" = true ]; then
+  PR_WORKFLOWS=$(printf '%s\n' "$WORKFLOW_PATHS" | while IFS= read -r path; do
     content=$(gh api "repos/$REPO/contents/$path?ref=$CURRENT_HEAD_SHA" --jq .content 2>/dev/null | base64 -d) || exit 1
     if printf '%s\n' "$content" | python3 -c '
 import re, sys
@@ -669,10 +682,11 @@ fi
 
 CI_EVIDENCE=$(jq -n \
   --argjson runs "${CHECK_RUNS:-null}" \
+  --argjson statuses "${COMMIT_STATUSES:-null}" \
   --argjson required "${REQUIRED:-null}" \
   --argjson rulesets "${RULESETS:-null}" --argjson workflows "${PR_WORKFLOWS:-null}" \
-  --arg check_ok "$CHECK_RUNS_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
-  '{check_runs_ok: ($check_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]?]), pr_workflows: $workflows}')
+  --arg check_ok "$CHECK_RUNS_OK" --arg status_ok "$COMMIT_STATUSES_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
+  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]?]), pr_workflows: $workflows}')
 CI_RESULT=$(printf '%s' "$CI_EVIDENCE" | python3 "$CI_DIR/ci_gate.py")
 CI_CLASSIFICATION=$(echo "$CI_RESULT" | jq -r .classification)
 CI_REASON=$(echo "$CI_RESULT" | jq -r .reason)

--- a/skills/ops/cto-review/stages/01-setup/CONTEXT.md
+++ b/skills/ops/cto-review/stages/01-setup/CONTEXT.md
@@ -59,6 +59,7 @@ gh api "repos/$REPO/issues?state=open&per_page=10" --jq '.[].title'
 ```bash
 gh pr view $PR --repo $REPO --json number,title,body,headRefName,headRefOid,baseRefName,url,files,labels,author,additions,deletions,commits
 CURRENT_HEAD_SHA=$(gh pr view $PR --repo $REPO --json headRefOid --jq '.headRefOid')
+BASE_BRANCH=$(gh pr view $PR --repo $REPO --json baseRefName --jq '.baseRefName')
 
 # Existing labels
 gh pr view $PR --repo $REPO --json labels --jq '.labels[].name'
@@ -609,10 +610,79 @@ Also pull dependency-manifest changes explicitly so they are easy to spot:
 gh pr diff $PR --repo $REPO -- "**/package.json" "**/Gemfile" "**/requirements.txt" "**/go.mod" "**/pyproject.toml"
 ```
 
-8. Fetch CI status (the review and act stages must honor it):
+8. Classify CI once at the reviewed head (the review and act stages consume this authoritative
+   result; never substitute `gh pr checks` exit status). The classifier is fail-closed: an API,
+   authorization, JSON, workflow-parsing, or required-context lookup failure is `block`, not an
+   empty check set. Collect all three expected-check sources at `CURRENT_HEAD_SHA`:
+
 ```bash
-gh pr checks $PR --repo $REPO || echo "CHECKS_UNAVAILABLE"
+CI_DIR="skills/cto-review/stages/01-setup"
+test -f "$CI_DIR/ci_gate.py" || CI_DIR="skills/ops/cto-review/stages/01-setup"
+
+# Check-runs response for the exact reviewed SHA. Preserve API failure separately from zero runs.
+CHECK_RUNS=$(gh api "repos/$REPO/commits/$CURRENT_HEAD_SHA/check-runs?per_page=100" 2>/dev/null) || CHECK_RUNS_OK=false
+: "${CHECK_RUNS_OK:=true}"
+
+# A 404 means no branch protection is configured; every other failure remains a block.
+REQUIRED=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/tmp/cto-required.err) || REQUIRED_STATUS=$?
+if grep -q '404' /tmp/cto-required.err; then
+  REQUIRED='{"contexts":[]}'
+  REQUIRED_OK=true
+elif [ "${REQUIRED_STATUS:-0}" = "0" ]; then
+  REQUIRED_OK=true
+else
+  REQUIRED_OK=false
+fi
+
+# Rulesets can add required checks independently of legacy branch protection. A 404 means no
+# matching ruleset; any other error is evidence we cannot safely classify as N/A.
+RULESETS=$(gh api "repos/$REPO/rules/branches/$BASE_BRANCH" 2>/tmp/cto-rulesets.err) || RULESETS_STATUS=$?
+if grep -q '404' /tmp/cto-rulesets.err; then
+  RULESETS='[]'
+elif [ "${RULESETS_STATUS:-0}" != "0" ]; then
+  REQUIRED_OK=false
+fi
+
+# Enumerate workflow files at the PR head. Parse every declaration; a lookup or parsing failure
+# blocks rather than incorrectly waiving CI. `pr_workflows` holds PR-triggered workflows only.
+WORKFLOW_TREE=$(gh api "repos/$REPO/git/trees/$CURRENT_HEAD_SHA?recursive=1" 2>/dev/null) || WORKFLOW_TREE_OK=false
+: "${WORKFLOW_TREE_OK:=true}"
+PR_WORKFLOWS='[]'
+if [ "$WORKFLOW_TREE_OK" = true ]; then
+  PR_WORKFLOWS=$(echo "$WORKFLOW_TREE" | python3 -c '
+import json, sys
+for item in json.load(sys.stdin).get("tree", []):
+    path = item.get("path", "")
+    if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml")):
+        print(path)
+' | while IFS= read -r path; do
+    content=$(gh api "repos/$REPO/contents/$path?ref=$CURRENT_HEAD_SHA" --jq .content 2>/dev/null | base64 -d) || exit 1
+    if printf '%s\n' "$content" | python3 -c '
+import re, sys
+text = sys.stdin.read()
+trigger = re.compile(r"^[ \\t]*(pull_request|pull_request_target|[\\\"\\x27](pull_request|pull_request_target)[\\\"\\x27])[ \\t]*:", re.M)
+inline = re.compile(r"^[ \\t]*on[ \\t]*:[^#\\n]*(pull_request|pull_request_target)", re.M)
+sys.exit(0 if trigger.search(text) or inline.search(text) else 1)
+'; then printf '%s\n' "$path"; fi
+  done | jq -Rsc 'split("\n") | map(select(length > 0))') || WORKFLOW_TREE_OK=false
+fi
+
+CI_EVIDENCE=$(jq -n \
+  --argjson runs "${CHECK_RUNS:-null}" \
+  --argjson required "${REQUIRED:-null}" \
+  --argjson rulesets "${RULESETS:-null}" --argjson workflows "${PR_WORKFLOWS:-null}" \
+  --arg check_ok "$CHECK_RUNS_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
+  '{check_runs_ok: ($check_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]?]), pr_workflows: $workflows}')
+CI_RESULT=$(printf '%s' "$CI_EVIDENCE" | python3 "$CI_DIR/ci_gate.py")
+CI_CLASSIFICATION=$(echo "$CI_RESULT" | jq -r .classification)
+CI_REASON=$(echo "$CI_RESULT" | jq -r .reason)
+echo "[cto-review] CI classification: $CI_CLASSIFICATION — $CI_REASON"
 ```
+
+`pass` requires every observed check to be completed with conclusion `success`. `block` covers a
+pending, failing, cancelled, skipped, neutral, unknown, or missing expected check. Only a successful
+zero-check response with no required context and no pull-request workflow is
+`na-no-configured-checks`; render its receipt exactly as `CI: N/A — no configured checks`.
 
 9. Resolve the team merge strategy from Pylot's DB-authoritative live team
    configuration. Automated merge authority is explicit: only
@@ -668,7 +738,10 @@ Labels present at stage-01 time: {comma-separated list, or "none"}
 - mergedAt: {timestamp or null}
 - mergeCommit: {oid or null}
 - short_circuit: {none | closed-no-merge | missing-staging-evidence}
-- ci_status: {passing | failing | pending | unavailable}
+- ci_classification: {pass | block | na-no-configured-checks}
+- ci_receipt: {"CI: N/A — no configured checks" for N/A, otherwise the classifier reason}
+- ci_observed_checks: {check-run names/status/conclusion from the reviewed head}
+- ci_expected_checks: {required contexts/ruleset checks and PR workflow paths, or "none"}
 - merge_strategy: {auto | label-only}
 
 ## Visual Evidence
@@ -714,7 +787,8 @@ Labels present at stage-01 time: {comma-separated list, or "none"}
   waiver applied and its rationale echoed when it fires.
 - Visual evidence evaluated after it, and only if it did not short-circuit. Its verdict is recorded
   as `notice`; it never sets a short_circuit and never suppresses stages 02/03.
-- For `open`/`merged`: full diff, metadata, repo context, CI status, and merge strategy all captured.
+- For `open`/`merged`: full diff, metadata, repo context, CI classification/evidence, and merge
+  strategy all captured.
 - For `closed-no-merge` or `missing-staging-evidence`: short_circuit set; remaining gathering skipped.
 
 ## Failure

--- a/skills/ops/cto-review/stages/01-setup/ci_gate.py
+++ b/skills/ops/cto-review/stages/01-setup/ci_gate.py
@@ -17,42 +17,52 @@ RECEIPT_NA = "CI: N/A — no configured checks"
 def classify_ci(payload: dict[str, Any]) -> dict[str, str]:
     """Classify CI evidence collected at one reviewed PR head.
 
-    All three sources must be collected successfully.  `expected_checks` combines
+    All four sources must be collected successfully.  `expected_checks` combines
     branch-protection/ruleset contexts; `pr_workflows` contains only workflow files
-    that declare a pull-request trigger at the reviewed head.
+    that declare a pull-request trigger at the reviewed head; `commit_statuses`
+    captures legacy status contexts which are not returned by the check-runs API.
     """
-    for source in ("check_runs", "expected_checks", "pr_workflows"):
+    for source in ("check_runs", "commit_statuses", "expected_checks", "pr_workflows"):
         if not payload.get(f"{source}_ok", False):
             return {"classification": BLOCK, "reason": f"{source} lookup failed"}
 
     runs = payload.get("check_runs")
+    statuses = payload.get("commit_statuses")
     expected = payload.get("expected_checks")
     workflows = payload.get("pr_workflows")
-    if not isinstance(runs, list) or not isinstance(expected, list) or not isinstance(workflows, list):
+    if (not isinstance(runs, list) or not isinstance(statuses, list)
+            or not isinstance(expected, list) or not isinstance(workflows, list)):
         return {"classification": BLOCK, "reason": "CI evidence has an invalid shape"}
 
     if not all(isinstance(name, str) for name in expected) or not all(isinstance(path, str) for path in workflows):
         return {"classification": BLOCK, "reason": "expected CI evidence has an invalid shape"}
 
-    observed = {run.get("name") for run in runs if isinstance(run, dict) and isinstance(run.get("name"), str)}
+    if not all(isinstance(run, dict) and isinstance(run.get("name"), str) and run["name"] for run in runs):
+        return {"classification": BLOCK, "reason": "invalid check-run record"}
+    if not all(isinstance(status, dict) and isinstance(status.get("context"), str) and status["context"]
+               for status in statuses):
+        return {"classification": BLOCK, "reason": "invalid commit-status record"}
+
+    observed = {run["name"] for run in runs} | {status["context"] for status in statuses}
     missing = [name for name in expected if name not in observed]
     if missing:
         return {"classification": BLOCK, "reason": f"expected check missing: {missing[0]}"}
 
-    if not runs:
+    if not runs and not statuses:
         if expected or workflows:
             source = "expected check" if expected else "pull-request workflow"
             return {"classification": BLOCK, "reason": f"no check runs returned despite configured {source}"}
         return {"classification": NA, "reason": RECEIPT_NA}
 
     for run in runs:
-        if not isinstance(run, dict):
-            return {"classification": BLOCK, "reason": "invalid check-run record"}
-        name = run.get("name", "unnamed check")
+        name = run["name"]
         if run.get("status") != "completed":
             return {"classification": BLOCK, "reason": f"check pending: {name}"}
         if run.get("conclusion") != "success":
             return {"classification": BLOCK, "reason": f"check not successful: {name}"}
+    for status in statuses:
+        if status.get("state") != "success":
+            return {"classification": BLOCK, "reason": f"commit status not successful: {status['context']}"}
     return {"classification": PASS, "reason": "all observed checks successful"}
 
 

--- a/skills/ops/cto-review/stages/01-setup/ci_gate.py
+++ b/skills/ops/cto-review/stages/01-setup/ci_gate.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Fail-closed CI classification shared by the cto-review setup procedure and fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+NA = "na-no-configured-checks"
+PASS = "pass"
+BLOCK = "block"
+RECEIPT_NA = "CI: N/A — no configured checks"
+
+
+def classify_ci(payload: dict[str, Any]) -> dict[str, str]:
+    """Classify CI evidence collected at one reviewed PR head.
+
+    All three sources must be collected successfully.  `expected_checks` combines
+    branch-protection/ruleset contexts; `pr_workflows` contains only workflow files
+    that declare a pull-request trigger at the reviewed head.
+    """
+    for source in ("check_runs", "expected_checks", "pr_workflows"):
+        if not payload.get(f"{source}_ok", False):
+            return {"classification": BLOCK, "reason": f"{source} lookup failed"}
+
+    runs = payload.get("check_runs")
+    expected = payload.get("expected_checks")
+    workflows = payload.get("pr_workflows")
+    if not isinstance(runs, list) or not isinstance(expected, list) or not isinstance(workflows, list):
+        return {"classification": BLOCK, "reason": "CI evidence has an invalid shape"}
+
+    if not all(isinstance(name, str) for name in expected) or not all(isinstance(path, str) for path in workflows):
+        return {"classification": BLOCK, "reason": "expected CI evidence has an invalid shape"}
+
+    observed = {run.get("name") for run in runs if isinstance(run, dict) and isinstance(run.get("name"), str)}
+    missing = [name for name in expected if name not in observed]
+    if missing:
+        return {"classification": BLOCK, "reason": f"expected check missing: {missing[0]}"}
+
+    if not runs:
+        if expected or workflows:
+            source = "expected check" if expected else "pull-request workflow"
+            return {"classification": BLOCK, "reason": f"no check runs returned despite configured {source}"}
+        return {"classification": NA, "reason": RECEIPT_NA}
+
+    for run in runs:
+        if not isinstance(run, dict):
+            return {"classification": BLOCK, "reason": "invalid check-run record"}
+        name = run.get("name", "unnamed check")
+        if run.get("status") != "completed":
+            return {"classification": BLOCK, "reason": f"check pending: {name}"}
+        if run.get("conclusion") != "success":
+            return {"classification": BLOCK, "reason": f"check not successful: {name}"}
+    return {"classification": PASS, "reason": "all observed checks successful"}
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(json.dumps({"classification": BLOCK, "reason": f"CI evidence parse failed: {exc}"}))
+        return
+    print(json.dumps(classify_ci(payload), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
+++ b/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Collect fail-closed CI evidence for one immutable PR head.  Output is one JSON object.
-set -u
+set -u -o pipefail
 
 REPO=${1:?usage: collect_ci_evidence.sh org/repo head-sha}
 HEAD_SHA=${2:?usage: collect_ci_evidence.sh org/repo head-sha}
@@ -81,6 +81,7 @@ for item in payload["tree"]:
 fi
 if [ "$WORKFLOW_TREE_OK" = true ]; then
   PR_WORKFLOWS=$(printf '%s\n' "$WORKFLOW_PATHS" | while IFS= read -r path; do
+    [ -n "$path" ] || continue
     content=$(gh api "repos/$REPO/contents/$path?ref=$HEAD_SHA" --jq .content 2>/dev/null | base64 -d) || exit 1
     if printf '%s\n' "$content" | python3 -c '
 import re, sys
@@ -100,4 +101,4 @@ jq -n \
   --argjson required "${REQUIRED:-null}" \
   --argjson rulesets "${RULESETS:-null}" --argjson workflows "${PR_WORKFLOWS:-null}" \
   --arg check_ok "$CHECK_RUNS_OK" --arg status_ok "$COMMIT_STATUSES_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
-  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]?]), pr_workflows: $workflows}'
+  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]? | if type == "object" then .context else . end]), pr_workflows: $workflows}'

--- a/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
+++ b/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Collect fail-closed CI evidence for one immutable PR head.  Output is one JSON object.
+set -u
+
+REPO=${1:?usage: collect_ci_evidence.sh org/repo head-sha}
+HEAD_SHA=${2:?usage: collect_ci_evidence.sh org/repo head-sha}
+# The caller supplies the PR base branch because required checks are branch-specific.
+BASE_BRANCH=${3:?usage: collect_ci_evidence.sh org/repo head-sha base-branch}
+
+CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" 2>/dev/null) || CHECK_RUNS_OK=false
+: "${CHECK_RUNS_OK:=true}"
+COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" 2>/dev/null) || COMMIT_STATUSES_OK=false
+: "${COMMIT_STATUSES_OK:=true}"
+
+REQUIRED=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/tmp/cto-required.err) || REQUIRED_STATUS=$?
+if grep -q '404' /tmp/cto-required.err; then
+  REQUIRED='{"contexts":[]}'
+  REQUIRED_OK=true
+elif [ "${REQUIRED_STATUS:-0}" = "0" ]; then
+  REQUIRED_OK=true
+else
+  REQUIRED_OK=false
+fi
+
+RULESETS=$(gh api "repos/$REPO/rules/branches/$BASE_BRANCH" 2>/tmp/cto-rulesets.err) || RULESETS_STATUS=$?
+if grep -q '404' /tmp/cto-rulesets.err; then
+  RULESETS='[]'
+elif [ "${RULESETS_STATUS:-0}" != "0" ]; then
+  REQUIRED_OK=false
+fi
+
+WORKFLOW_TREE=$(gh api "repos/$REPO/git/trees/$HEAD_SHA?recursive=1" 2>/dev/null) || WORKFLOW_TREE_OK=false
+: "${WORKFLOW_TREE_OK:=true}"
+PR_WORKFLOWS='[]'
+if [ "$WORKFLOW_TREE_OK" = true ]; then
+  WORKFLOW_PATHS=$(echo "$WORKFLOW_TREE" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("truncated") is True or not isinstance(payload.get("tree"), list):
+    sys.exit(1)
+for item in payload["tree"]:
+    if not isinstance(item, dict):
+        sys.exit(1)
+    path = item.get("path", "")
+    if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml")):
+        print(path)
+') || WORKFLOW_TREE_OK=false
+fi
+if [ "$WORKFLOW_TREE_OK" = true ]; then
+  PR_WORKFLOWS=$(printf '%s\n' "$WORKFLOW_PATHS" | while IFS= read -r path; do
+    content=$(gh api "repos/$REPO/contents/$path?ref=$HEAD_SHA" --jq .content 2>/dev/null | base64 -d) || exit 1
+    if printf '%s\n' "$content" | python3 -c '
+import re, sys
+text = sys.stdin.read()
+trigger = re.compile(r"^[ \\t]*(pull_request|pull_request_target|[\\\"\\x27](pull_request|pull_request_target)[\\\"\\x27])[ \\t]*:", re.M)
+inline = re.compile(r"^[ \\t]*on[ \\t]*:[^#\\n]*(pull_request|pull_request_target)", re.M)
+sys.exit(0 if trigger.search(text) or inline.search(text) else 1)
+'; then printf '%s\n' "$path"; fi
+  done | jq -Rsc 'split("\n") | map(select(length > 0))') || WORKFLOW_TREE_OK=false
+fi
+
+jq -n \
+  --argjson runs "${CHECK_RUNS:-null}" \
+  --argjson statuses "${COMMIT_STATUSES:-null}" \
+  --argjson required "${REQUIRED:-null}" \
+  --argjson rulesets "${RULESETS:-null}" --argjson workflows "${PR_WORKFLOWS:-null}" \
+  --arg check_ok "$CHECK_RUNS_OK" --arg status_ok "$COMMIT_STATUSES_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
+  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]?]), pr_workflows: $workflows}'

--- a/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
+++ b/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
@@ -7,10 +7,43 @@ HEAD_SHA=${2:?usage: collect_ci_evidence.sh org/repo head-sha}
 # The caller supplies the PR base branch because required checks are branch-specific.
 BASE_BRANCH=${3:?usage: collect_ci_evidence.sh org/repo head-sha base-branch}
 
-CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" 2>/dev/null) || CHECK_RUNS_OK=false
+# Fetch every page and prove the response is complete. A green first page cannot
+# establish merge safety when GitHub reports more evidence than it returned there.
+collect_paginated() {
+  local endpoint=$1 item_key=$2 page=1 expected=-1 count=0 previous=0 response parsed total items
+  local collected='[]'
+  while :; do
+    response=$(gh api "${endpoint}?per_page=100&page=$page" 2>/dev/null) || return 1
+    parsed=$(printf '%s' "$response" | jq -ce --arg key "$item_key" '
+      if type != "object"
+         or (.total_count | type) != "number"
+         or (.total_count < 0)
+         or ((.total_count | floor) != .total_count)
+         or (.[$key] | type) != "array"
+      then error("malformed paginated CI response")
+      else {total_count, items: .[$key]}
+      end
+    ') || return 1
+    total=$(printf '%s' "$parsed" | jq -r .total_count)
+    items=$(printf '%s' "$parsed" | jq -c .items)
+    if [ "$expected" = -1 ]; then expected=$total; elif [ "$expected" != "$total" ]; then return 1; fi
+    previous=$count
+    collected=$(jq -cn --argjson prior "$collected" --argjson next "$items" '$prior + $next') || return 1
+    count=$(printf '%s' "$collected" | jq 'length') || return 1
+    if [ "$count" -gt "$expected" ]; then return 1; fi
+    if [ "$count" = "$expected" ]; then printf '%s\n' "$collected"; return 0; fi
+    # An empty page before total_count is reached is incomplete evidence.
+    if [ "$count" = "$previous" ]; then return 1; fi
+    page=$((page + 1))
+  done
+}
+
+CHECK_RUNS_ITEMS=$(collect_paginated "repos/$REPO/commits/$HEAD_SHA/check-runs" check_runs) || CHECK_RUNS_OK=false
 : "${CHECK_RUNS_OK:=true}"
-COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" 2>/dev/null) || COMMIT_STATUSES_OK=false
+CHECK_RUNS=$(jq -cn --argjson items "${CHECK_RUNS_ITEMS:-null}" '{check_runs: $items}')
+COMMIT_STATUS_ITEMS=$(collect_paginated "repos/$REPO/commits/$HEAD_SHA/status" statuses) || COMMIT_STATUSES_OK=false
 : "${COMMIT_STATUSES_OK:=true}"
+COMMIT_STATUSES=$(jq -cn --argjson items "${COMMIT_STATUS_ITEMS:-null}" '{statuses: $items}')
 
 REQUIRED=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/tmp/cto-required.err) || REQUIRED_STATUS=$?
 if grep -q '404' /tmp/cto-required.err; then
@@ -52,9 +85,11 @@ if [ "$WORKFLOW_TREE_OK" = true ]; then
     if printf '%s\n' "$content" | python3 -c '
 import re, sys
 text = sys.stdin.read()
-trigger = re.compile(r"^[ \\t]*(pull_request|pull_request_target|[\\\"\\x27](pull_request|pull_request_target)[\\\"\\x27])[ \\t]*:", re.M)
-inline = re.compile(r"^[ \\t]*on[ \\t]*:[^#\\n]*(pull_request|pull_request_target)", re.M)
-sys.exit(0 if trigger.search(text) or inline.search(text) else 1)
+event = r"(?:pull_request|pull_request_target)"
+mapping = re.compile(rf"^[ \\t]*(?:{event}|[\\\"\\x27]{event}[\\\"\\x27])[ \\t]*:", re.M)
+inline = re.compile(rf"^[ \\t]*on[ \\t]*:[^#\\n]*(?:{event})", re.M)
+block_list = re.compile(rf"^[ \\t]*on[ \\t]*:[ \\t]*(?:#.*)?$[\\s\\S]*?^[ \\t]+-[ \\t]*(?:[\\\"\\x27]?{event}[\\\"\\x27]?)(?:[ \\t]*(?:#.*)?)$", re.M)
+sys.exit(0 if mapping.search(text) or inline.search(text) or block_list.search(text) else 1)
 '; then printf '%s\n' "$path"; fi
   done | jq -Rsc 'split("\n") | map(select(length > 0))') || WORKFLOW_TREE_OK=false
 fi

--- a/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
+++ b/skills/ops/cto-review/stages/01-setup/collect_ci_evidence.sh
@@ -50,7 +50,21 @@ if grep -q '404' /tmp/cto-required.err; then
   REQUIRED='{"contexts":[]}'
   REQUIRED_OK=true
 elif [ "${REQUIRED_STATUS:-0}" = "0" ]; then
-  REQUIRED_OK=true
+  # A successful response is evidence only when it has the documented shape.
+  # Do not normalize malformed required-check configurations into an empty set.
+  if printf '%s' "$REQUIRED" | jq -e '
+    type == "object"
+    and (.contexts | type == "array")
+    and all(.contexts[]; type == "string")
+    and ((has("checks") | not) or (
+      (.checks | type == "array")
+      and all(.checks[]; type == "string" or (type == "object" and (.context | type == "string")))
+    ))
+  ' >/dev/null; then
+    REQUIRED_OK=true
+  else
+    REQUIRED_OK=false
+  fi
 else
   REQUIRED_OK=false
 fi
@@ -58,8 +72,29 @@ fi
 RULESETS=$(gh api "repos/$REPO/rules/branches/$BASE_BRANCH" 2>/tmp/cto-rulesets.err) || RULESETS_STATUS=$?
 if grep -q '404' /tmp/cto-rulesets.err; then
   RULESETS='[]'
+  RULESETS_OK=true
 elif [ "${RULESETS_STATUS:-0}" != "0" ]; then
-  REQUIRED_OK=false
+  RULESETS_OK=false
+elif printf '%s' "$RULESETS" | jq -e '
+  type == "array"
+  and all(.[];
+    type == "object"
+    and (.rules | type == "array")
+    and all(.rules[];
+      type == "object"
+      and (if .type == "required_status_checks" then
+        (.parameters | type == "object")
+        and (.parameters.required_status_checks | type == "array")
+        and all(.parameters.required_status_checks[];
+          type == "string" or (type == "object" and (.context | type == "string"))
+        )
+      else true end)
+    )
+  )
+' >/dev/null; then
+  RULESETS_OK=true
+else
+  RULESETS_OK=false
 fi
 
 WORKFLOW_TREE=$(gh api "repos/$REPO/git/trees/$HEAD_SHA?recursive=1" 2>/dev/null) || WORKFLOW_TREE_OK=false
@@ -100,5 +135,5 @@ jq -n \
   --argjson statuses "${COMMIT_STATUSES:-null}" \
   --argjson required "${REQUIRED:-null}" \
   --argjson rulesets "${RULESETS:-null}" --argjson workflows "${PR_WORKFLOWS:-null}" \
-  --arg check_ok "$CHECK_RUNS_OK" --arg status_ok "$COMMIT_STATUSES_OK" --arg required_ok "$REQUIRED_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
-  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]? | if type == "object" then .context else . end]), pr_workflows: $workflows}'
+  --arg check_ok "$CHECK_RUNS_OK" --arg status_ok "$COMMIT_STATUSES_OK" --arg required_ok "$REQUIRED_OK" --arg rulesets_ok "$RULESETS_OK" --arg workflow_ok "$WORKFLOW_TREE_OK" \
+  '{check_runs_ok: ($check_ok == "true"), commit_statuses_ok: ($status_ok == "true"), expected_checks_ok: ($required_ok == "true" and $rulesets_ok == "true"), pr_workflows_ok: ($workflow_ok == "true"), check_runs: ($runs.check_runs // null), commit_statuses: ($statuses.statuses // null), expected_checks: (($required.contexts // []) + ($required.checks // [] | map(.context // .)) + [$rulesets[]?.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]? | if type == "object" then .context else . end]), pr_workflows: $workflows}'

--- a/skills/ops/cto-review/stages/01-setup/test_ci_gate.py
+++ b/skills/ops/cto-review/stages/01-setup/test_ci_gate.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Executable regression corpus for cto-review's three-state CI gate."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from ci_gate import BLOCK, NA, PASS, RECEIPT_NA, classify_ci  # noqa: E402
+
+
+GREEN = {"name": "test", "status": "completed", "conclusion": "success"}
+
+
+def evidence(**overrides):
+    result = {
+        "check_runs_ok": True,
+        "expected_checks_ok": True,
+        "pr_workflows_ok": True,
+        "check_runs": [],
+        "expected_checks": [],
+        "pr_workflows": [],
+    }
+    result.update(overrides)
+    return result
+
+
+def expect(name, expected, **payload):
+    result = classify_ci(evidence(**payload))
+    assert result["classification"] == expected, f"{name}: {result}"
+    return result
+
+
+def main() -> None:
+    # Empty successful evidence is the only N/A path. This replays pylot PR #3176.
+    replay = expect(
+        "#3176 replay at 287675ba092984550cc8cfaf5c588bcdb56f0f20",
+        NA,
+        check_runs=[],
+        expected_checks=[],
+        pr_workflows=[],
+    )
+    assert replay["reason"] == RECEIPT_NA
+
+    expect("configured green", PASS, check_runs=[GREEN], expected_checks=["test"])
+    for conclusion in ("failure", "cancelled", "skipped", "neutral", "timed_out", "unknown"):
+        expect(f"non-success conclusion {conclusion}", BLOCK,
+               check_runs=[{**GREEN, "conclusion": conclusion}])
+    expect("pending", BLOCK, check_runs=[{**GREEN, "status": "in_progress", "conclusion": None}])
+    expect("expected but absent", BLOCK, check_runs=[GREEN], expected_checks=["required-lint"])
+    expect("workflow configured but no run", BLOCK, pr_workflows=[".github/workflows/ci.yml"])
+    for source in ("check_runs", "expected_checks", "pr_workflows"):
+        expect(f"{source} lookup failure", BLOCK, **{f"{source}_ok": False})
+    expect("malformed collection", BLOCK, check_runs={"total_count": 0})
+    expect("malformed expected check", BLOCK, expected_checks=[{"context": "test"}])
+    print("ci_gate: 16 fixtures passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ops/cto-review/stages/01-setup/test_ci_gate.py
+++ b/skills/ops/cto-review/stages/01-setup/test_ci_gate.py
@@ -16,9 +16,11 @@ GREEN = {"name": "test", "status": "completed", "conclusion": "success"}
 def evidence(**overrides):
     result = {
         "check_runs_ok": True,
+        "commit_statuses_ok": True,
         "expected_checks_ok": True,
         "pr_workflows_ok": True,
         "check_runs": [],
+        "commit_statuses": [],
         "expected_checks": [],
         "pr_workflows": [],
     }
@@ -44,17 +46,25 @@ def main() -> None:
     assert replay["reason"] == RECEIPT_NA
 
     expect("configured green", PASS, check_runs=[GREEN], expected_checks=["test"])
+    expect("legacy status context green", PASS,
+           commit_statuses=[{"context": "legacy-test", "state": "success"}],
+           expected_checks=["legacy-test"])
+    expect("legacy status context failing", BLOCK,
+           commit_statuses=[{"context": "legacy-test", "state": "failure"}])
     for conclusion in ("failure", "cancelled", "skipped", "neutral", "timed_out", "unknown"):
         expect(f"non-success conclusion {conclusion}", BLOCK,
                check_runs=[{**GREEN, "conclusion": conclusion}])
     expect("pending", BLOCK, check_runs=[{**GREEN, "status": "in_progress", "conclusion": None}])
     expect("expected but absent", BLOCK, check_runs=[GREEN], expected_checks=["required-lint"])
     expect("workflow configured but no run", BLOCK, pr_workflows=[".github/workflows/ci.yml"])
-    for source in ("check_runs", "expected_checks", "pr_workflows"):
+    for source in ("check_runs", "commit_statuses", "expected_checks", "pr_workflows"):
         expect(f"{source} lookup failure", BLOCK, **{f"{source}_ok": False})
     expect("malformed collection", BLOCK, check_runs={"total_count": 0})
     expect("malformed expected check", BLOCK, expected_checks=[{"context": "test"}])
-    print("ci_gate: 16 fixtures passed")
+    expect("nameless successful check run", BLOCK,
+           check_runs=[{"status": "completed", "conclusion": "success"}])
+    expect("malformed commit status", BLOCK, commit_statuses=[{"state": "success"}])
+    print("ci_gate: 21 fixtures passed")
 
 
 if __name__ == "__main__":

--- a/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
+++ b/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Regression coverage for fail-closed evidence collection."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("collect_ci_evidence.sh")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        fake_bin = Path(tempdir)
+        gh = fake_bin / "gh"
+        gh.write_text("""#!/usr/bin/env bash
+case "$*" in
+  *check-runs*) echo '{"check_runs":[]}' ;;
+  */status*) echo '{"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":true,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+        gh.chmod(0o755)
+        env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "example/repo", "a" * 40, "develop"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    evidence = json.loads(result.stdout)
+    assert evidence["pr_workflows_ok"] is False, evidence
+    print("collect_ci_evidence: truncated tree blocks")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
+++ b/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("collect_ci_evidence.sh")
+GATE = Path(__file__).with_name("ci_gate.py")
+SETUP_CONTEXT = Path(__file__).with_name("CONTEXT.md")
 
 
 def run_collector(fake_gh: str) -> dict:
@@ -30,7 +32,23 @@ def run_collector(fake_gh: str) -> dict:
     return json.loads(result.stdout)
 
 
+def classify(evidence: dict) -> dict:
+    result = subprocess.run(
+        ["python3", str(GATE)],
+        input=json.dumps(evidence),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
 def main() -> None:
+    # Stage 01 must invoke this collector, rather than reimplementing a partial
+    # first-page-only query before handing evidence to the shared classifier.
+    setup = SETUP_CONTEXT.read_text()
+    assert 'CI_EVIDENCE=$(bash "$CI_DIR/collect_ci_evidence.sh" "$REPO" "$CURRENT_HEAD_SHA" "$BASE_BRANCH")' in setup
+
     truncated = run_collector("""case "$*" in
   *check-runs*) echo '{"total_count":0,"check_runs":[]}' ;;
   */status*) echo '{"total_count":0,"statuses":[]}' ;;
@@ -54,6 +72,7 @@ esac
 """)
     assert list_trigger["pr_workflows_ok"] is True, list_trigger
     assert list_trigger["pr_workflows"] == [".github/workflows/ci.yml"], list_trigger
+    assert classify(list_trigger)["classification"] == "block", list_trigger
 
     paginated = run_collector("""case "$*" in
   *check-runs*\&page=1*) python3 -c 'import json; print(json.dumps({"total_count": 101, "check_runs": [{"name": f"green-{i}", "status": "completed", "conclusion": "success"} for i in range(100)]}))' ;;
@@ -68,6 +87,7 @@ esac
     assert paginated["check_runs_ok"] is True, paginated
     assert len(paginated["check_runs"]) == 101, paginated
     assert paginated["check_runs"][-1]["name"] == "late-failure", paginated
+    assert classify(paginated)["classification"] == "block", paginated
 
     incomplete = run_collector("""case "$*" in
   *check-runs*) echo '{"total_count":2,"check_runs":[]}' ;;
@@ -79,7 +99,7 @@ esac
 esac
 """)
     assert incomplete["check_runs_ok"] is False, incomplete
-    print("collect_ci_evidence: truncated tree, list trigger, and pagination regressions pass")
+    print("stage-01 CI collection: truncated tree, list trigger, and late pagination failures pass")
 
 
 if __name__ == "__main__":

--- a/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
+++ b/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
@@ -99,6 +99,30 @@ esac
     assert required_ruleset["expected_checks"] == ["ruleset-ci"], required_ruleset
     assert classify(required_ruleset)["classification"] == "pass", required_ruleset
 
+    malformed_required = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":0,"check_runs":[]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert malformed_required["expected_checks_ok"] is False, malformed_required
+    assert classify(malformed_required)["classification"] == "block", malformed_required
+
+    malformed_rulesets = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":0,"check_runs":[]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '{}' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert malformed_rulesets["expected_checks_ok"] is False, malformed_rulesets
+    assert classify(malformed_rulesets)["classification"] == "block", malformed_rulesets
+
     paginated = run_collector("""case "$*" in
   *check-runs*\&page=1*) python3 -c 'import json; print(json.dumps({"total_count": 101, "check_runs": [{"name": f"green-{i}", "status": "completed", "conclusion": "success"} for i in range(100)]}))' ;;
   *check-runs*\&page=2*) echo '{"total_count":101,"check_runs":[{"name":"late-failure","status":"completed","conclusion":"failure"}]}' ;;
@@ -124,7 +148,7 @@ esac
 esac
 """)
     assert incomplete["check_runs_ok"] is False, incomplete
-    print("stage-01 CI collection: truncated tree, list trigger, workflow-content failure, ruleset context, and late pagination failures pass")
+    print("stage-01 CI collection: truncated tree, list trigger, workflow-content failure, malformed expected-check payloads, ruleset context, and late pagination failures pass")
 
 
 if __name__ == "__main__":

--- a/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
+++ b/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
@@ -74,6 +74,31 @@ esac
     assert list_trigger["pr_workflows"] == [".github/workflows/ci.yml"], list_trigger
     assert classify(list_trigger)["classification"] == "block", list_trigger
 
+    workflow_content_failure = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":0,"check_runs":[]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[{"path":".github/workflows/ci.yml"}]}' ;;
+  *contents*) exit 1 ;;
+  *) exit 1 ;;
+esac
+""")
+    assert workflow_content_failure["pr_workflows_ok"] is False, workflow_content_failure
+    assert classify(workflow_content_failure)["classification"] == "block", workflow_content_failure
+
+    required_ruleset = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":1,"check_runs":[{"name":"ruleset-ci","status":"completed","conclusion":"success"}]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[{"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"ruleset-ci"}]}}]}]' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert required_ruleset["expected_checks"] == ["ruleset-ci"], required_ruleset
+    assert classify(required_ruleset)["classification"] == "pass", required_ruleset
+
     paginated = run_collector("""case "$*" in
   *check-runs*\&page=1*) python3 -c 'import json; print(json.dumps({"total_count": 101, "check_runs": [{"name": f"green-{i}", "status": "completed", "conclusion": "success"} for i in range(100)]}))' ;;
   *check-runs*\&page=2*) echo '{"total_count":101,"check_runs":[{"name":"late-failure","status":"completed","conclusion":"failure"}]}' ;;
@@ -99,7 +124,7 @@ esac
 esac
 """)
     assert incomplete["check_runs_ok"] is False, incomplete
-    print("stage-01 CI collection: truncated tree, list trigger, and late pagination failures pass")
+    print("stage-01 CI collection: truncated tree, list trigger, workflow-content failure, ruleset context, and late pagination failures pass")
 
 
 if __name__ == "__main__":

--- a/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
+++ b/skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
@@ -13,20 +13,11 @@ from pathlib import Path
 SCRIPT = Path(__file__).with_name("collect_ci_evidence.sh")
 
 
-def main() -> None:
+def run_collector(fake_gh: str) -> dict:
     with tempfile.TemporaryDirectory() as tempdir:
         fake_bin = Path(tempdir)
         gh = fake_bin / "gh"
-        gh.write_text("""#!/usr/bin/env bash
-case "$*" in
-  *check-runs*) echo '{"check_runs":[]}' ;;
-  */status*) echo '{"statuses":[]}' ;;
-  *required_status_checks*) echo '{"contexts":[]}' ;;
-  *rules/branches*) echo '[]' ;;
-  *git/trees*) echo '{"truncated":true,"tree":[]}' ;;
-  *) exit 1 ;;
-esac
-""")
+        gh.write_text("#!/usr/bin/env bash\n" + fake_gh)
         gh.chmod(0o755)
         env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
         result = subprocess.run(
@@ -36,9 +27,59 @@ esac
             text=True,
             env=env,
         )
-    evidence = json.loads(result.stdout)
-    assert evidence["pr_workflows_ok"] is False, evidence
-    print("collect_ci_evidence: truncated tree blocks")
+    return json.loads(result.stdout)
+
+
+def main() -> None:
+    truncated = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":0,"check_runs":[]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":true,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert truncated["pr_workflows_ok"] is False, truncated
+
+    list_trigger = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":0,"check_runs":[]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[{"path":".github/workflows/ci.yml"}]}' ;;
+  *contents*) printf '%s' 'b246ICAtIHB1bGxfcmVxdWVzdAo=' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert list_trigger["pr_workflows_ok"] is True, list_trigger
+    assert list_trigger["pr_workflows"] == [".github/workflows/ci.yml"], list_trigger
+
+    paginated = run_collector("""case "$*" in
+  *check-runs*\&page=1*) python3 -c 'import json; print(json.dumps({"total_count": 101, "check_runs": [{"name": f"green-{i}", "status": "completed", "conclusion": "success"} for i in range(100)]}))' ;;
+  *check-runs*\&page=2*) echo '{"total_count":101,"check_runs":[{"name":"late-failure","status":"completed","conclusion":"failure"}]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert paginated["check_runs_ok"] is True, paginated
+    assert len(paginated["check_runs"]) == 101, paginated
+    assert paginated["check_runs"][-1]["name"] == "late-failure", paginated
+
+    incomplete = run_collector("""case "$*" in
+  *check-runs*) echo '{"total_count":2,"check_runs":[]}' ;;
+  */status*) echo '{"total_count":0,"statuses":[]}' ;;
+  *required_status_checks*) echo '{"contexts":[]}' ;;
+  *rules/branches*) echo '[]' ;;
+  *git/trees*) echo '{"truncated":false,"tree":[]}' ;;
+  *) exit 1 ;;
+esac
+""")
+    assert incomplete["check_runs_ok"] is False, incomplete
+    print("collect_ci_evidence: truncated tree, list trigger, and pagination regressions pass")
 
 
 if __name__ == "__main__":

--- a/skills/ops/cto-review/stages/02-review/CONTEXT.md
+++ b/skills/ops/cto-review/stages/02-review/CONTEXT.md
@@ -8,7 +8,7 @@ cohesion, with every dimension weighed against the same full diff at once.
 - `.procedure-output/cto-review/01-setup/handoff.md`
 
 ## Task
-Read the setup handoff — the full diff, PR metadata, repo context, merge state, CI status, ALL PR
+Read the setup handoff — the full diff, PR metadata, repo context, merge state, CI classification, ALL PR
 comments, and the label snapshot. Before forming a verdict:
 1. Run the **judgement layer** (step 0 below) — read all labels and all comments, identify every
    blocker, determine resolved/unresolved with evidence.
@@ -158,8 +158,11 @@ Decide the verdict using this table:
 | BLOCKED | External dependency or missing info | `needs-work` label; post what is needed, do NOT dispatch |
 | NEW_ISSUE | Review reveals separate work needed | Approve PR on its own merits; flag a separate issue |
 
-**Never recommend merge if CI is red** (`ci_status: failing`) — force the verdict to BLOCKED/hold and
-note the CI failure, regardless of how clean the diff is.
+**Never recommend merge if `ci_classification: block`** — force the verdict to BLOCKED/hold and
+note the classifier reason, regardless of how clean the diff is. `pass` and
+`na-no-configured-checks` may proceed only through the ordinary whole-diff verdict; N/A is not a
+generic bypass. For N/A, render exactly `CI: N/A — no configured checks` and state that the lane
+test receipts and deploy-time release corpus gate remain in force.
 
 ## Action items
 List numbered, specific, actionable must-do items. "Update docs" is not actionable;
@@ -230,7 +233,9 @@ Lane: {fast | staging | none — from the setup handoff}
 Fast lane (#2996): double-check and the pre-merge staging deploy did not run. Compensating
 controls in force: review-pr findings + review-state ledger, this cohesive review, the #2918
 owner hard-stop (lane-independent), CI green, and the in-deploy full corpus gate that still
-guards prod on every release train. A missing `double-checked` label is expected here.
+guards prod on every release train. If CI is N/A, replace "CI green" with `CI: N/A — no configured
+checks`; lane test receipts and the deploy-time release corpus gate remain the applicable controls.
+A missing `double-checked` label is expected here.
 Comments checked: {N} (last author: {login})
 Blockers found:
 | Blocker | Type | Status | Evidence |
@@ -248,7 +253,8 @@ Blockers found:
 - Judgement layer (Step 0) ran: labels read, all comments processed, each blocker classified.
 - Receipts block populated — labels seen, comment count, blockers → status.
 - Checklist tables and action items populated with no unresolved TBD/TODO.
-- CI-red forces a non-merge verdict.
+- `ci_classification: block` forces a non-merge verdict; pass and N/A remain subject to every
+  other review and merge requirement.
 
 ## Failure
 - Setup handoff missing or unreadable → write handoff with `verdict: BLOCKED` and reason "setup

--- a/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
+++ b/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
@@ -195,7 +195,8 @@ controls the owner traded the staging net for:
 1. review-pr's findings and the `review-state v1` ledger (still-open findings are verdict inputs).
 2. This stage's own cohesive whole-diff judgement.
 3. The #2918 owner hard-stop at Step 2 — lane-independent, above.
-4. CI green — unchanged, and never merged red (Hard Rule 9).
+4. CI pass or `CI: N/A — no configured checks` — unchanged as a merge prerequisite, and never
+   merged when the Stage 01 classification is block (Hard Rule 9).
 5. **The in-deploy full corpus gate.** The fast lane skips the *pre-merge staging deploy*; it does
    not touch the release train. `scripts/ci-release-gate.sh` still runs the unscoped corpus before
    anything reaches production, on every train, for every commit that lands on develop. A fast-lane
@@ -219,12 +220,17 @@ fi
 Only proceed to a merge if ALL hold:
 1. Stage 02 `merge_decision` is `merge` (verdict LGTM / "merge immediately").
 2. `MISSING` is empty — i.e. the lane's required labels from Step 3 are all present.
-3. CI is green.
+3. Stage 01 `ci_classification` is `pass` or `na-no-configured-checks` (never re-run or
+   reinterpret `gh pr checks`; `block` is a hold).
 4. Step 2 (owner gate) did NOT fire.
 
 ```bash
-# Verify CI is green
-gh pr checks $PR --repo $REPO
+# Consume the single, reviewed-head CI classification from Stage 01.
+CI_CLASSIFICATION=$(sed -n 's/^- ci_classification: //p' .procedure-output/cto-review/01-setup/handoff.md | head -1)
+case "$CI_CLASSIFICATION" in
+  pass|na-no-configured-checks) ;;
+  *) echo "[cto-review] CI merge prerequisite: BLOCKED ($CI_CLASSIFICATION)"; exit 0 ;;
+esac
 
 # Verify required labels
 gh pr view $PR --repo $REPO --json labels --jq '.labels[].name'
@@ -261,8 +267,10 @@ else
   echo "Labeled ready-to-merge (merge_strategy: ${MERGE_STRATEGY:-missing}; automated merge requires exact auto)"
 fi
 ```
-If CI is failing: do NOT merge — the verdict should already be hold; note the CI failure in the
-comment if not already noted. Record the action taken: `merged` | `labeled` | `closed-superseded` | `held` (CI-red only — never for a conflict).
+If CI classification is `block`: do NOT merge — the verdict should already be hold; note the
+classifier reason in the comment if not already noted. Record the action taken: `merged` |
+`labeled` | `closed-superseded` | `held` (CI-block only — never for a conflict). N/A is permitted
+only after the normal verdict, lane labels, and unconditional owner gate have all passed.
 
 ### Step 6: Write the report file (local only — NO Quest)
 Use the template in `shared/report-format.md`:
@@ -301,7 +309,7 @@ Path: `.procedure-output/cto-review/03-synthesize-act/handoff.md`
 - owner_gate_fired: {true (label: security|waiting-on-owner) | false}
 - comment_posted: {url or "skipped (closed-no-merge)" or "park comment (owner gate)"}
 - label_applied: {approved | needs-work | ready-to-merge | waiting-on-owner (gate) | none}
-- merge_action: {merged | labeled-ready-to-merge | closed-superseded | held (CI-red only) | parked (owner gate) | skipped (already merged) | skipped (closed)}
+- merge_action: {merged | labeled-ready-to-merge | closed-superseded | held (CI-block only) | parked (owner gate) | skipped (already merged) | skipped (closed)}
 - report_path: {path}
 
 ## Outcome

--- a/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
+++ b/skills/ops/cto-review/stages/03-synthesize-act/CONTEXT.md
@@ -220,17 +220,36 @@ fi
 Only proceed to a merge if ALL hold:
 1. Stage 02 `merge_decision` is `merge` (verdict LGTM / "merge immediately").
 2. `MISSING` is empty — i.e. the lane's required labels from Step 3 are all present.
-3. Stage 01 `ci_classification` is `pass` or `na-no-configured-checks` (never re-run or
-   reinterpret `gh pr checks`; `block` is a hold).
+3. Stage 01 and a fresh, structured merge-time CI classification are both `pass` or
+   `na-no-configured-checks` (never interpret `gh pr checks`; `block` is a hold).
 4. Step 2 (owner gate) did NOT fire.
 
 ```bash
-# Consume the single, reviewed-head CI classification from Stage 01.
-CI_CLASSIFICATION=$(sed -n 's/^- ci_classification: //p' .procedure-output/cto-review/01-setup/handoff.md | head -1)
+# The stage-01 receipt establishes what was reviewed; it cannot authorize a changed head or a
+# configuration added while review ran. Re-read the head and collect the same structured evidence
+# immediately before merge. Any API, tree, parse, or classifier failure is a hold.
+REVIEWED_HEAD_SHA=$(sed -n 's/^- Current HEAD SHA: //p' .procedure-output/cto-review/01-setup/handoff.md | head -1)
+CURRENT_MERGE_HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null) || {
+  echo "[cto-review] CI merge prerequisite: BLOCKED (PR head lookup failed)"; exit 0;
+}
+if [ -z "$REVIEWED_HEAD_SHA" ] || [ "$CURRENT_MERGE_HEAD_SHA" != "$REVIEWED_HEAD_SHA" ]; then
+  echo "[cto-review] CI merge prerequisite: BLOCKED (head changed since review)"; exit 0
+fi
+BASE_BRANCH=$(gh pr view "$PR" --repo "$REPO" --json baseRefName --jq '.baseRefName' 2>/dev/null) || {
+  echo "[cto-review] CI merge prerequisite: BLOCKED (base branch lookup failed)"; exit 0;
+}
+CI_DIR="skills/cto-review/stages/01-setup"
+test -f "$CI_DIR/ci_gate.py" || CI_DIR="skills/ops/cto-review/stages/01-setup"
+CI_EVIDENCE=$(bash "$CI_DIR/collect_ci_evidence.sh" "$REPO" "$CURRENT_MERGE_HEAD_SHA" "$BASE_BRANCH") || {
+  echo "[cto-review] CI merge prerequisite: BLOCKED (evidence collection failed)"; exit 0;
+}
+CI_RESULT=$(printf '%s' "$CI_EVIDENCE" | python3 "$CI_DIR/ci_gate.py")
+CI_CLASSIFICATION=$(printf '%s' "$CI_RESULT" | jq -r '.classification // "block"' 2>/dev/null)
 case "$CI_CLASSIFICATION" in
   pass|na-no-configured-checks) ;;
   *) echo "[cto-review] CI merge prerequisite: BLOCKED ($CI_CLASSIFICATION)"; exit 0 ;;
 esac
+echo "[cto-review] CI merge prerequisite: $CI_CLASSIFICATION"
 
 # Verify required labels
 gh pr view $PR --repo $REPO --json labels --jq '.labels[].name'


### PR DESCRIPTION
Implements fellowship-dev/pylot#3182.

## Summary
- distinguish repositories with no configured PR checks from missing, incomplete, malformed, pending, or failed evidence
- recognize list-form pull-request workflow triggers
- paginate check-runs and legacy statuses with completeness guards
- recollect exact-head evidence immediately before merge

## Verification
- `python3 skills/ops/cto-review/stages/01-setup/test_ci_gate.py`: 21 fixtures passed
- `python3 skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py`: truncated tree, list trigger, workflow-content failure, ruleset context, and late-pagination regressions passed

Post-merge acceptance: sync the skill catalog, verify the S3/catalog hash, and replay a real no-check PR through CTO review.