### PR TITLE
ci: run all skill test entry points on PR/push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  run-all-test-entry-points:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies (ripgrep, PyYAML)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep
+          python3 -m pip install --quiet pyyaml
+
+      - name: Guard — every test file must be in the explicit list below
+        run: |
+          found=$(find . -path ./.git -prune -o \( -name '*.test.sh' -o -name 'test_*.py' \) -print | sort)
+          listed=$(grep -oE '^\s+\./skills/\S+' .github/workflows/tests.yml | tr -d ' ' | sort -u)
+          if [ "$found" != "$listed" ]; then
+            echo "Test entry points on disk do not match the list in tests.yml."
+            echo "Add/remove the file(s) below in the 'Run all test entry points' step:"
+            diff <(echo "$found") <(echo "$listed") || true
+            exit 1
+          fi
+
+      - name: Run all test entry points
+        run: |
+          tests='
+            ./skills/ops/cto-review/stages/01-setup/test_ci_gate.py
+            ./skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
+            ./skills/ops/cto-review/stages/01-setup/test_evidence_gate.py
+            ./skills/ops/cto-review/stages/01-setup/test_visual_gate.py
+            ./skills/ops/double-check/tests/exact-head-receipt.test.sh
+            ./skills/ops/dx-metrics/scripts/dxm-aggregate.test.sh
+            ./skills/ops/dx-metrics/scripts/dxm-dashboard.test.sh
+            ./skills/ops/dx-metrics/scripts/dxm-identity.test.sh
+            ./skills/ops/dx-metrics/scripts/dxm-trends.test.sh
+            ./skills/ops/flowchad-runner/scripts/test_validate_contract.py
+            ./skills/ops/seo-ops/scripts/test_audit.py
+            ./skills/ops/speckit-runner/tests/pr-postcondition.test.sh
+            ./skills/ops/speckit-runner/tests/verification-receipts.test.sh
+          '
+          failed=""
+          for t in $tests; do
+            case "$t" in
+              *.py) interp=python3 ;;
+              *)    interp=bash ;;
+            esac
+            echo "::group::$t"
+            if "$interp" "$t"; then
+              echo "PASS $t"
+            else
+              echo "FAIL $t"
+              failed="$failed $t"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "Failed entry points:"
+            for t in $failed; do echo "  $t"; done
+            exit 1
+          fi
+          echo "All test entry points passed."

--- a/skills/ops/dx-metrics/scripts/dxm-dashboard.test.sh
+++ b/skills/ops/dx-metrics/scripts/dxm-dashboard.test.sh
@@ -71,7 +71,7 @@ ENV1="$("$DASH" --scope org --scope-key acme --period week --since 2026-06-01 --
 eq "default render exits 0" "$RC" "0"
 OUT1="$(printf '%s' "$ENV1" | python3 -c 'import json,sys;print(json.load(sys.stdin)["out"])' 2>/dev/null)"
 [ -n "$OUT1" ] && [ -f "$OUT1" ] && ok "wrote a file" || bad "wrote a file" "$OUT1"
-eq "file is chmod 600" "$(stat -f '%Lp' "$OUT1" 2>/dev/null || stat -c '%a' "$OUT1")" "600"
+eq "file is chmod 600" "$(stat -c '%a' "$OUT1" 2>/dev/null || stat -f '%Lp' "$OUT1")" "600"
 printf '%s' "$ENV1" | python3 -c 'import json,sys;json.load(sys.stdin)' 2>/dev/null \
   && ok "envelope is valid JSON" || bad "envelope is valid JSON" "$ENV1"
 

--- a/skills/ops/dx-metrics/scripts/dxm-identity.test.sh
+++ b/skills/ops/dx-metrics/scripts/dxm-identity.test.sh
@@ -261,7 +261,7 @@ SQ() { sqlite3 "$SEED_DB" "$1"; }
 
 grep -q '^email' "$SEED_HOME/identity/identity-overrides.tsv" 2>/dev/null \
   && ok "seed installed when no override file exists" || bad "seed installed"
-chk "seed file is chmod 600" "$(stat -f '%Lp' "$SEED_HOME/identity/identity-overrides.tsv" 2>/dev/null || stat -c '%a' "$SEED_HOME/identity/identity-overrides.tsv")" "600"
+chk "seed file is chmod 600" "$(stat -c '%a' "$SEED_HOME/identity/identity-overrides.tsv" 2>/dev/null || stat -f '%Lp' "$SEED_HOME/identity/identity-overrides.tsv")" "600"
 chk "glob override matched both EC2 hostnames" \
   "$(SQ "SELECT COUNT(*) FROM identity_emails e JOIN identities i USING(identity_id) WHERE i.login='dxm-machine-ec2-devbox';")" "2"
 chk "glob override did NOT insert the pattern as an address" \

--- a/skills/ops/dx-metrics/scripts/dxm-trends.test.sh
+++ b/skills/ops/dx-metrics/scripts/dxm-trends.test.sh
@@ -189,7 +189,7 @@ has   "the not-a-performance-tool notice is present" "$OUT_D" "must"
 eq "svg elements were emitted" \
    "$(grep -c '<svg ' "$OUT_D")" "$(grep -c '</svg>' "$OUT_D")"
 eq "no placeholder survived" "$(grep -c '__[A-Z][A-Z]*__' "$OUT_D")" "0"
-eq "file mode is 600" "$(stat -f '%Lp' "$OUT_D" 2>/dev/null || stat -c '%a' "$OUT_D")" "600"
+eq "file mode is 600" "$(stat -c '%a' "$OUT_D" 2>/dev/null || stat -f '%Lp' "$OUT_D")" "600"
 
 echo
 echo "== 6. PRIVACY: the default file names nobody =="


### PR DESCRIPTION
The repo has 13 test entry points and nothing ran them on PRs (found during the #149/#150 ceremony-retirement work). This adds one workflow, one ubuntu-latest job, triggered on `pull_request` and push to `main`.

## What it does
- Installs the two missing deps: **ripgrep** (the double-check test shells out to `rg`) and **PyYAML** (flowchad-runner contract test). jq/sqlite3/node/gh/python3 are already on the runner.
- **Guard step**: diffs `find`-discovered test files against the explicit list in the workflow, so a new `.test.sh`/`test_*.py` can't silently skip CI.
- Runs every entry point (bash for `.test.sh`, python3 for `test_*.py`) with `::group::` per-file output; runs all before failing, then lists failures.

## Entry points (13, current `main`)
- skills/ops/cto-review/stages/01-setup/test_ci_gate.py
- skills/ops/cto-review/stages/01-setup/test_collect_ci_evidence.py
- skills/ops/cto-review/stages/01-setup/test_evidence_gate.py
- skills/ops/cto-review/stages/01-setup/test_visual_gate.py
- skills/ops/double-check/tests/exact-head-receipt.test.sh
- skills/ops/dx-metrics/scripts/dxm-aggregate.test.sh
- skills/ops/dx-metrics/scripts/dxm-dashboard.test.sh
- skills/ops/dx-metrics/scripts/dxm-identity.test.sh
- skills/ops/dx-metrics/scripts/dxm-trends.test.sh
- skills/ops/flowchad-runner/scripts/test_validate_contract.py
- skills/ops/seo-ops/scripts/test_audit.py
- skills/ops/speckit-runner/tests/pr-postcondition.test.sh
- skills/ops/speckit-runner/tests/verification-receipts.test.sh

## Local run evidence
- On `main` (08b81d5): all 13 PASS (exact workflow loop, with rg + PyYAML available).
- On PR #150's branch (`149-perpr-ceremony`, 151303e): all 12 remaining entry points PASS. #150 deletes `speckit-runner/tests/verification-receipts.test.sh`, so whichever PR lands second needs a one-line list edit — the guard step will flag exactly that, which is it working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZCbPAswTQAGALmzbNgBrS


<!-- pylot:admission pr=151 cursor=690b45eee997 head=bd5435466e14dde45284d61419a797958b996839 stage=double-checked transition=double-checked->staging receipt=IC_kwDOSAB8H88AAAABSXpLSA producer=comment context=double-check receipt_sha=bd5435466e14dde45284d61419a797958b996839 -->
