### PR TITLE
retire(cto-review, review-pr): per-PR staging gate + lane machinery (owner ruling 2026-09-06)

### DIFF
--- a/skills/ops/cto-review/SKILL.md
+++ b/skills/ops/cto-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cto-review
-description: Use when performing a CTO-level PR review — includes a staging evidence gate for infra/backend PRs and a non-blocking visual evidence notice for UI PRs.
+description: Use when performing a CTO-level PR review — includes a staging evidence gate for release-train PRs (base = default branch; per-PR staging retired 2026-09-06, pylot#3389) and a non-blocking visual evidence notice for UI PRs.
 user-invocable: true
 allowed-tools: Read, Bash, Glob, Grep, Task
 ---
@@ -77,8 +77,10 @@ After stage 01 completes, read `.procedure-output/cto-review/01-setup/handoff.md
 
 - If `short_circuit: closed-no-merge` → skip stage 02, go straight to stage 03 (which posts
   nothing and emits the blocked/closed outcome).
-- If `short_circuit: missing-staging-evidence` → **DO NOT run stage 02 or 03**. Instead, run
-  these steps inline:
+- If `short_circuit: missing-staging-evidence` → **only possible on a RELEASE-TRAIN PR**
+  (base = default branch; owner ruling 2026-09-06, pylot#3389 — ordinary PRs never require
+  staging evidence and must never produce this short-circuit). **DO NOT run stage 02 or 03**.
+  Instead, run these steps inline:
   1. Apply `needs-work` label:
      ```bash
      gh pr edit {PR} --repo {org/repo} --add-label "needs-work"
@@ -86,11 +88,11 @@ After stage 01 completes, read `.procedure-output/cto-review/01-setup/handoff.md
   2. Post rejection comment:
      ```bash
      gh pr comment {PR} --repo {org/repo} \
-       --body "Missing staging evidence. Deploy to staging with \`/test-in-staging\` and include the output before requesting re-review."
+       --body "Release train is missing fresh staging evidence at its head. Run \`/test-in-staging\` for this train and include the output before requesting re-review (per-release staging is mandatory — pylot#3389)."
      ```
   3. Emit outcome:
      ```
-     [pylot] outcome="cto-review blocked: missing staging evidence on PR #{PR}" status=blocked
+     [pylot] outcome="cto-review blocked: release train missing staging evidence on PR #{PR}" status=blocked
      ```
   Then stop — no further stages.
 - Otherwise → continue to stage 02.
@@ -148,6 +150,7 @@ Post the comment, apply the label, merge-or-label, write the report file, and em
    │
    ├── short_circuit: closed-no-merge ──────────────────────► 03 (no-op)
    └── short_circuit: missing-staging-evidence ──► inline rejection (no stages 02/03)
+       (release-train PRs only — base = default branch; pylot#3389)
 
    (visual evidence: notice only — flows through 02/03 as an advisory line, never blocks)
 ```
@@ -158,7 +161,7 @@ Post the comment, apply the label, merge-or-label, write the report file, and em
 - **Failure**: failing stage emits `[pylot] outcome="cto-review failed at stage NN: {reason}" status=failed`
 - **Blocked (closed)**: `[pylot] outcome="cto-review skipped: PR #{N} closed without merge" status=blocked`
 - **Blocked (owner gate)**: `[pylot] outcome="cto-review parked: PR #{N} carries {label} — owner review required" status=blocked` (#2918 — fires when `security` OR `waiting-on-owner` is present at merge time; park comment + `waiting-on-owner` label applied)
-- **Blocked (staging evidence)**: `[pylot] outcome="cto-review blocked: missing staging evidence on PR #{N}" status=blocked` (fires only when staging IS required AND no valid fresh evidence was found in body or comments)
+- **Blocked (staging evidence)**: `[pylot] outcome="cto-review blocked: release train missing staging evidence on PR #{N}" status=blocked` (fires ONLY on a release-train PR — base = default branch — with no valid fresh evidence in body or comments; ordinary PRs never require staging evidence per the 2026-09-06 owner ruling)
 
 ## Hard Rules
 
@@ -174,10 +177,10 @@ Post the comment, apply the label, merge-or-label, write the report file, and em
    `na-no-configured-checks`. Only pass or N/A may satisfy the CI prerequisite; N/A still requires
    the normal review, lane, owner-gate, and merge-authority requirements.
 10. **No Quest** — reporting is the local report file only.
-11. **The staging gate fires first and is the only evidence short-circuit** (step 5.5). On that
-    short-circuit, skip everything else and post its rejection inline. It cannot be bypassed by
-    prose or by verdict, and has exactly ONE mechanical waiver beyond its own path check:
-    `lane:fast` (#2996), applied by the label, not by argument.
+11. **The staging gate fires first and is the only evidence short-circuit** (step 5.5). It
+    applies to release-train PRs only (base = default branch, pylot#3389); on any other PR it
+    must never fire. On the short-circuit, skip everything else and post its rejection inline.
+    It cannot be bypassed by prose or by verdict.
     **Visual evidence (step 5.6) is a notice, never a blocker** — it is evaluated after staging,
     recorded in the handoff, and appended by stage 03 as an advisory line. It never short-circuits,
     never applies a label, and never gates the merge bar. Its notice MUST still name the self-serve
@@ -196,16 +199,16 @@ Post the comment, apply the label, merge-or-label, write the report file, and em
     posts. No silent LGTM without an enumeration of what was checked. On a fast-lane PR the
     receipts must also name the lane and the compensating controls (Step 3.1 list) — the whole
     point of the trade is that it is stated, not assumed.
-15. **The lane changes the merge BAR, never the review BAR (#2996)** — `lane:fast` removes exactly
-    two things: the `double-checked` label requirement, and the staging-evidence requirement. It
-    removes nothing from stage 02's depth, nothing from CI, and nothing from the #2918 owner gate,
-    which is lane-independent and fires identically in both lanes. A missing `double-checked` on a
-    `lane:fast` PR is the expected state — never `needs-work` it, never ask for a double-check,
-    never dispatch one. The lane is read from a FRESH GitHub label read at merge time; a PR with no
-    lane label is treated as `lane:staging`. Fast is opt-in, never inferred.
-16. **The fast lane does not touch prod's gate (#2996)** — it skips the PRE-MERGE staging deploy,
-    not the release train. `scripts/ci-release-gate.sh` still runs the unscoped full corpus before
-    anything reaches production. A fast-lane merge is a merge to develop; prod is still gated.
+15. **Lanes are LEGACY (owner ruling 2026-09-06)** — `lane:fast`/`lane:staging` labels no longer
+    change the staging gate (retired for ordinary PRs) and are informational only. The merge bar
+    default is `reviewed double-checked`; the historical fast-lane exception (a `lane:fast` PR
+    where double-check was deliberately never dispatched) still merges on `reviewed` alone —
+    never `needs-work` such a PR for a missing `double-checked`. No new lane labels are emitted.
+16. **Prod's gate moved to the release train (pylot#3389)** — ordinary PRs merge to develop with
+    no staging deploy, by design. Every promote develop→default-branch train must carry fresh
+    `/test-in-staging` evidence at its exact head (this skill's stage-01 gate enforces it), and
+    `scripts/ci-release-gate.sh` still runs the unscoped full corpus before anything reaches
+    production. The staging *step* is mandatory per release; the release *count* is not.
 17. **Merge authority is explicit and DB-authoritative** — stage 01 MUST use
     `resolve-merge-strategy.sh`, which reads live team configuration through the Pylot CLI. Only
     `deploy.release_mode=ship` grants automated merge authority. `propose`, missing configuration,

--- a/skills/ops/cto-review/stages/01-setup/CONTEXT.md
+++ b/skills/ops/cto-review/stages/01-setup/CONTEXT.md
@@ -125,9 +125,10 @@ Record in the handoff:
 - `last_comment_author: {login | none}`
 - Full list of all comment bodies (stage 02 reads them to identify unresolved blockers)
 
-5.3. **Resolve the pipeline lane (#2996)** — one variable, read straight off the label snapshot
-from 5.2. It changes the staging-evidence gate (5.5) and the merge bar (stage 03), and nothing
-else. It never changes the review's depth or standards.
+5.3. **Pipeline lane labels are LEGACY (owner ruling 2026-09-06).** `lane:fast`/`lane:staging`
+labels may still appear on older PRs; record them in the handoff as `lane: {fast | staging |
+none}` for context, but they no longer change the staging-evidence gate, the merge bar, or
+anything else. Never wait on a lane label and never emit one.
 
 ```bash
 LANE="none"
@@ -135,57 +136,34 @@ case ",$(echo "$CURRENT_LABELS" | tr -d ' ')," in
   *,lane:fast,*)    LANE="fast" ;;
   *,lane:staging,*) LANE="staging" ;;
 esac
-echo "[cto-review] lane: $LANE"
+echo "[cto-review] lane (legacy, informational only): $LANE"
 ```
 
-Record `lane: {fast | staging | none}` in the handoff.
+5.5. **Staging evidence gate — RELEASE TRAINS ONLY (owner ruling 2026-09-06, pylot#3389).**
+Per-PR staging testing is retired: ordinary PRs (base = `develop` or any non-default branch)
+NEVER require staging evidence — test-in-staging deliberately does not run for them, and a
+missing-evidence short-circuit on such a PR is a bug, not a gate. The mandatory staging step
+lives on the **release train**: a PR whose base branch is the repo default branch (`main`/
+`master`, i.e. a promote/release PR) must carry fresh staging evidence at its exact head
+before merge. Only fires for open PRs; merged/closed PRs skip this gate entirely.
 
-`none` means the PR predates #2996 or its lane label never landed — treat it exactly as
-`staging`. Fast is opt-in and requires the explicit `lane:fast` label; there is no inference.
-
-5.5. **Staging evidence gate** — check BEFORE proceeding to the expensive diff/full-review path.
-Only fires for open PRs; merged/closed PRs skip this gate entirely.
-
-Run this bash block immediately after step 5 (requires `MERGE_STATE` set in step 3 and `LANE` set
-in step 5.3):
+Run this bash block immediately after step 5 (requires `MERGE_STATE` set in step 3):
 
 ```bash
 # Gate only fires for open PRs — merged/closed PRs skip evidence check
 if [ "${MERGE_STATE:-open}" = "open" ]; then
-  # Collect changed filenames
+  # Collect changed filenames (stage-02 handoff still wants them)
   CHANGED_FILES=$(gh pr diff $PR --repo $REPO --name-only 2>/dev/null || echo "")
 
-  # Detect if this PR touches infra/backend paths that require staging evidence.
-  # *.d.mts files are TypeScript type-declaration outputs — they never affect deployed runtime
-  # and are excluded from the necessity trigger (pylot#1861 fix 3).
+  # Staging evidence is required ONLY for release-train PRs: base = default branch.
+  BASE_BRANCH=$(gh pr view $PR --repo $REPO --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "")
+  DEFAULT_BRANCH=$(gh repo view $REPO --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
   NEEDS_EVIDENCE=false
-  while IFS= read -r f; do
-    case "$f" in
-      *.d.mts) ;;  # type-declaration files: exclude from necessity trigger
-      infra/*|gateway/*|crew.mjs) NEEDS_EVIDENCE=true; break ;;
-      */migrations/*.sql) NEEDS_EVIDENCE=true; break ;;
-    esac
-  done <<< "$CHANGED_FILES"
-
-  # ── FAST-LANE WAIVER (#2996) ────────────────────────────────────────────────
-  # WHY THIS IS NOT A HOLE: this gate's `gateway/*` trigger is a whole-directory
-  # approximation of "deployable surface". The #2996 lane classifier answers the same
-  # question with a precise path list (infra, CI, migrations, gateway/modules/auth/**,
-  # gateway/shared/route-capability.mts, secrets, Dockerfile*, harness-versions.json) —
-  # anything it puts on lane:fast provably touches none of them. Without this waiver the
-  # fast lane is dead on arrival: nearly every pylot PR touches gateway/*, so every fast-lane
-  # PR would arrive here, find no staging evidence (test-in-staging never ran, by design),
-  # and get bounced to needs-work — a rework loop that can never terminate.
-  # It is a WAIVER OF THE EVIDENCE REQUIREMENT ONLY. The #2918 owner gate, the visual-evidence
-  # gate, CI, the review findings and the in-deploy full corpus gate are all untouched.
-  if [ "$NEEDS_EVIDENCE" = "true" ] && [ "${LANE:-none}" = "fast" ]; then
-    NEEDS_EVIDENCE=false
-    echo "[cto-review] staging evidence gate: WAIVED — lane:fast (#2996); the lane classifier already proved the diff touches no infra/CI/migration/auth/secrets/Dockerfile/harness path, and test-in-staging is not expected to have run"
-  fi
-
-  # Record waiver rationale when the gate is not triggered (pylot#1861 fix 3).
-  if [ "$NEEDS_EVIDENCE" = "false" ] && [ -n "$CHANGED_FILES" ]; then
-    echo "[cto-review] staging evidence gate: WAIVED — no infra/gateway/migration paths in diff — staging not required"
+  if [ -n "$BASE_BRANCH" ] && [ "$BASE_BRANCH" = "$DEFAULT_BRANCH" ]; then
+    NEEDS_EVIDENCE=true
+    echo "[cto-review] staging evidence gate: REQUIRED — release-train PR (base=$BASE_BRANCH is the default branch); the train must carry fresh staging evidence at its head (pylot#3389)"
+  else
+    echo "[cto-review] staging evidence gate: NOT REQUIRED — base=$BASE_BRANCH is not the default branch; per-PR staging retired by owner ruling 2026-09-06"
   fi
 
   if [ "$NEEDS_EVIDENCE" = "true" ]; then

--- a/skills/ops/cto-review/stages/02-review/CONTEXT.md
+++ b/skills/ops/cto-review/stages/02-review/CONTEXT.md
@@ -62,9 +62,9 @@ comment and influences the verdict.
 | `needs-work` | Changes requested | Check if follow-up commits or comments show the issues were addressed; if yes → resolved; if no → unresolved blocker |
 | `waiting-on-owner` | Owner hold | Unresolved unless the owner has since commented with approval or label was removed; machine cannot clear this |
 | `security` | Auth/security hold | Unresolved unless owner has explicitly cleared it; machine cannot clear this |
-| `chad-rejects` | FlowChad QA failure | Unresolved unless a subsequent FlowChad verdict comment (`<!-- flowchad:verdict ... -->` / "FlowChad Results") shows PASSED; look for it in comments |
+| `chad-rejects` | FlowChad QA failure (LEGACY) | FlowChad per-PR runs were retired 2026-09-06 (pylot#3388); a stale `chad-rejects` from before then is context, not a blocker — weigh the underlying evidence comment on its merits |
 | `reviewed`, `double-checked`, `approved`, `dispatched`, `ready-to-work` | Pipeline labels | Not blockers |
-| `lane:fast`, `lane:staging` | #2996 pipeline lane | Not blockers. `lane:fast` means double-check, flowchad and test-in-staging were deliberately NOT dispatched. Their **absence is expected**, not an unresolved blocker — do not record "missing double-check" or "no staging evidence" as a blocker on a `lane:fast` PR, and do not let it lower the verdict. |
+| `lane:fast`, `lane:staging`, `chad-approves`, `staging-verified` | LEGACY labels (owner ruling 2026-09-06) | Not blockers, never wait on them. Per-PR flowchad and test-in-staging are retired: their absence is the expected state on EVERY ordinary PR — never record "no staging evidence" or "no FlowChad verdict" as a blocker or let it lower the verdict. Staging evidence is required only on release-train PRs (base = default branch, pylot#3389); the setup stage gates that. |
 
 **For each comment thread, identify blockers:**
 - Explicit hold comments (e.g. "do not merge", "waiting for owner") — resolved only if a subsequent comment or commit addresses them
@@ -227,14 +227,13 @@ Wrong-but-plausible: {none | list of findings}
 
 ## Receipts (#2918)
 Labels seen: {comma-separated list, or "none"}
-Lane: {fast | staging | none — from the setup handoff}
-{If lane is `fast`, add verbatim — the trade must be stated, never assumed:}
-Fast lane (#2996): double-check and the pre-merge staging deploy did not run. Compensating
-controls in force: review-pr's findings, this cohesive review, the #2918
-owner hard-stop (lane-independent), CI green, and the in-deploy full corpus gate that still
-guards prod on every release train. If CI is N/A, replace "CI green" with `CI: N/A — no configured
-checks`; lane test receipts and the deploy-time release corpus gate remain the applicable controls.
-A missing `double-checked` label is expected here.
+Lane: {fast | staging | none — legacy label from the setup handoff, informational only}
+{For every ordinary (non-release-train) PR, add verbatim — the trade must be stated, never assumed:}
+Per-PR staging retired (owner ruling 2026-09-06, pylot#3389): the pre-merge staging deploy did
+not run, by design. Compensating controls in force: review-pr's findings, double-check, this
+cohesive review, the #2918 owner hard-stop, CI green, and the mandatory staging run on the
+release train that still guards prod before every promote merge. If CI is N/A, replace "CI
+green" with `CI: N/A — no configured checks`.
 Comments checked: {N} (last author: {login})
 Blockers found:
 | Blocker | Type | Status | Evidence |

--- a/skills/ops/review-pr/stages/02-post/CONTEXT.md
+++ b/skills/ops/review-pr/stages/02-post/CONTEXT.md
@@ -110,90 +110,20 @@ fi
 - `APPLY_SECURITY` is consumed by Step 2.5 — it is an INPUT to the lane classifier, so this step
   must stay ahead of it.
 
-### Step 2.5: Apply lane Label (deterministic — #2996)
+### Step 2.5: Lane labels RETIRED (owner ruling 2026-09-06)
 
-The `lane:*` label routes the PR through one of two pipelines. It is computed by a script, never by
-judgement — the same posture as Step 2.
+The #2996 lane machinery is retired: per-PR flowchad and test-in-staging no longer run
+(automations disabled), every PR follows one pipeline — review-pr → double-check → cto-review —
+and staging testing is mandatory per RELEASE TRAIN instead (pylot#3389).
 
-- `lane:staging` → today's full pipeline: double-check → flowchad → test-in-staging → cto-review.
-- `lane:fast` → review → cto-review-with-merge-authority. No double-check, no staging deploy.
-
-The classifier is `scripts/classify-pr-surface.mts --lane` **in the repo under review**. It prints
-exactly one bare word on stdout (`fast` | `staging`), reasons on stderr, and **always exits 0** —
-on any internal failure it prints `staging`, so a broken classifier costs latency, never safety.
+**Do NOT apply, remove, or reason about `lane:*` labels.** Do not run
+`classify-pr-surface.mts --lane`. A `lane:*` label already present on an older PR is legacy
+context: leave it in place, never wait on it. Set `LANE="n/a"` for the handoff and move on:
 
 ```bash
-# Rollout dial (#2996): only these repos get a lane label at all. A repo not in this list
-# gets NO lane label, which is the fail-closed default — every automation behaves exactly as it
-# did before #2996. Widen this list one repo at a time; see ROLLOUT.md.
-LANE_ENABLED_REPOS="fellowship-dev/pylot"
-
-APPLY_LANE="false"
-for r in $LANE_ENABLED_REPOS; do [ "$r" = "$REPO" ] && APPLY_LANE="true"; done
-
-if [ "$APPLY_LANE" != "true" ]; then
-  echo "[review-pr] lane label NOT applied — $REPO is not lane-enabled (pre-#2996 pipeline)"
-  LANE="n/a"
-else
-  # The classifier lives in the repo under review. review-pr is read-only (Hard Rule 7) and
-  # never checks out code, so resolve it from the pod's working copy if present; otherwise
-  # fetch just that one file at the PR's base. If neither works, fail closed to staging.
-  CLASSIFIER=""
-  if [ -f "scripts/classify-pr-surface.mts" ]; then
-    CLASSIFIER="scripts/classify-pr-surface.mts"
-  else
-    mkdir -p /tmp/lane-2996
-    # BASE_BRANCH is set in stage 00 context (e.g. "main"). Required for the fallback fetch.
-    if gh api "repos/$REPO/contents/scripts/classify-pr-surface.mts?ref=$BASE_BRANCH" \
-         --jq '.content' 2>/dev/null | base64 -d > /tmp/lane-2996/classify-pr-surface.mts \
-       && [ -s /tmp/lane-2996/classify-pr-surface.mts ]; then
-      CLASSIFIER="/tmp/lane-2996/classify-pr-surface.mts"
-    fi
-  fi
-
-  if [ -z "$CLASSIFIER" ]; then
-    LANE="staging"
-    echo "[review-pr] lane classifier unavailable in $REPO — failing closed to lane:staging"
-  else
-    # `gh pr diff --name-only` is the same changed-file producer cto-review's staging-evidence
-    # gate uses, so the two gates can never disagree about what changed.
-    # $APPLY_SECURITY comes from Step 2: a security PR is never fast-laned.
-    LANE_LABELS=""
-    [ "$APPLY_SECURITY" = "true" ] && LANE_LABELS="security"
-    LANE_ARGS=""
-    [ -n "$LANE_LABELS" ] && LANE_ARGS="--labels $LANE_LABELS"
-    LANE=$(gh pr diff "$PR" --repo "$REPO" --name-only 2>/dev/null \
-            | node --import=tsx "$CLASSIFIER" --lane $LANE_ARGS - 2>/tmp/lane-2996-reasons.txt)
-    LANE=$(printf '%s' "$LANE" | tr -d '[:space:]')
-    # Belt-and-suspenders: anything that is not exactly "fast" is staging.
-    [ "$LANE" = "fast" ] || LANE="staging"
-    sed 's/^/[review-pr] /' /tmp/lane-2996-reasons.txt 2>/dev/null || true
-  fi
-
-  gh label create "lane:fast"    --repo $REPO --color "0e8a16" --description "#2996 fast lane — review + cto-review merge, no double-check/staging" 2>/dev/null || true
-  gh label create "lane:staging" --repo $REPO --color "5319e7" --description "#2996 staging lane — full pipeline (double-check, flowchad, test-in-staging)" 2>/dev/null || true
-  # Remove the opposite lane label if present (rework re-entry guard)
-  if [ "$LANE" = "fast" ]; then
-    gh pr edit $PR --repo $REPO --remove-label "lane:staging" 2>/dev/null || true
-  else
-    gh pr edit $PR --repo $REPO --remove-label "lane:fast" 2>/dev/null || true
-  fi
-  gh pr edit $PR --repo $REPO --add-label "lane:$LANE"
-  echo "[review-pr] lane label applied: lane:$LANE"
-fi
+LANE="n/a"
+echo "[review-pr] lane labels retired (owner ruling 2026-09-06) — none applied"
 ```
-
-**Rules:**
-- The lane is whatever the script says. Do **not** reason about it, do **not** override it, do
-  **not** "it's only a small gateway change" your way to `fast`. If the classification looks wrong,
-  the fix is a PR against `LANE_STAGING_GLOBS`, not a judgement call in this mission.
-- Anything that is not exactly the string `fast` becomes `staging`. Empty output, a crash, a
-  missing classifier, a repo that has no classifier — all resolve to `lane:staging`.
-- A PR that got `security` in Step 2 always lands on `lane:staging` (the classifier's own
-  `LANE_STAGING_LABELS` rule). #2918 and #2996 reinforce each other; neither replaces the other.
-- Apply exactly ONE lane label. If the PR already carries the other one from a previous run, remove
-  it first: `gh pr edit $PR --repo $REPO --remove-label "lane:fast"` (or `lane:staging`).
-- This step runs BEFORE Step 3. See the ordering note above — it is the whole point.
 
 ### Step 3: Apply reviewed Label — LAST
 


### PR DESCRIPTION
Skill-side half of the 2026-09-06 SDLC reshape (see fellowship-dev/pylot#3388 + fellowship-dev/pylot#3389). Automations were disabled same day; this aligns the skills so cto-review stops short-circuiting ordinary PRs for missing staging evidence (which no longer exists by design) and review-pr stops emitting lane labels.

Staging evidence is now required exactly once: on release-train PRs (base = default branch), enforced by cto-review stage 01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZCbPAswTQAGALmzbNgBrS